### PR TITLE
fix: スマホ実機でのライトモード時の文字色を修正

### DIFF
--- a/src/app/(frontend)/in_event/page.tsx
+++ b/src/app/(frontend)/in_event/page.tsx
@@ -17,8 +17,8 @@ export default async function InEventPage() {
         <Breadcrumb />
       </div>
       <section className={WRAP}>
-        <h1 className="text-3xl font-semibold mb-8">Events</h1>
-        {inEvent.length === 0 && <p>現在予定されているイベントはありません。</p>}
+        <h1 className="text-3xl font-semibold mb-8 text-gray-900 dark:text-white">Events</h1>
+        {inEvent.length === 0 && <p className="text-gray-700 dark:text-gray-300">現在予定されているイベントはありません。</p>}
         <div className="grid gap-6 sm:grid-cols-2">
           {inEvent.map((e) => (
             <EventCard key={e.id} e={e} />

--- a/src/components/cards/EventCard.tsx
+++ b/src/components/cards/EventCard.tsx
@@ -105,8 +105,8 @@ export default function EventCard({ e }: { e: Event }) {
           <h3
             className="
               font-bold text-xl leading-tight
-              text-gray-900 dark:!text-white
-              group-hover:!text-blue-600 dark:group-hover:!text-blue-400
+              text-gray-900 dark:text-white!
+              group-hover:text-blue-600! dark:group-hover:text-blue-400!
               transition-colors duration-300
               line-clamp-2
             "

--- a/src/components/cards/EventCard.tsx
+++ b/src/components/cards/EventCard.tsx
@@ -105,7 +105,7 @@ export default function EventCard({ e }: { e: Event }) {
           <h3
             className="
               font-bold text-xl leading-tight
-              dark:!text-white
+              text-gray-900 dark:!text-white
               group-hover:!text-blue-600 dark:group-hover:!text-blue-400
               transition-colors duration-300
               line-clamp-2


### PR DESCRIPTION
## 問題

スマホ実機でライトモード時にイベントページのテキストが白色になり、読めなくなる問題がありました。

- PCブラウザでは正常に表示
- PCのレスポンシブモードでも再現せず
- スマホ実機のみで発生

## 原因

スマホブラウザはOS設定のダークモードを優先するため、CSSで色を明示的に指定していないテキストに対して、Webサイトのライト/ダークモードに関わらず、OSのダークモード設定に基づいて色を適用していました。

## 変更内容

### 修正ファイル

- `src/app/(frontend)/in_event/page.tsx`
  - h1タイトル: `text-gray-900 dark:text-white` を追加
  - 空メッセージ: `text-gray-700 dark:text-gray-300` を追加

- `src/components/cards/EventCard.tsx`
  - イベントタイトル: `text-gray-900` を追加（`dark:!text-white` は既存）

### 修正方法

ライトモード用（`text-gray-900`）とダークモード用（`dark:text-white`）の両方の色を明示的に指定することで、OS設定に左右されない表示を実現しました。

## テスト計画

- [ ] スマホ実機（ライトモード）でイベントページのテキストが正しく表示されることを確認
- [ ] スマホ実機（ダークモード）でイベントページのテキストが正しく表示されることを確認
- [ ] PCブラウザで両モードの表示に問題がないことを確認
- [ ] イベントカードのタイトルが両モードで正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * イベントページの見出し（H1）とプレースホルダ段落にダークモード用のテキスト色を追加しました。
  * イベントカードのタイトル（h3）でライトモードの既定色とホバー色を調整し、両モードでの視認性とホバー挙動を改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->