### PR TITLE
fix: .card-linkのcolor:inheritがTailwindクラスを上書きする根本原因を修正

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -197,8 +197,12 @@ p a:focus {
 .card-link,
 nav a,
 header a {
-  color: inherit;
   text-decoration: none;
+}
+
+/* card-link配下でも子要素の色指定を優先 */
+.card-link > * {
+  color: inherit;
 }
 
 .card-link:focus,

--- a/src/components/cards/EventCard.tsx
+++ b/src/components/cards/EventCard.tsx
@@ -97,7 +97,7 @@ export default function EventCard({ e }: { e: Event }) {
   {platform.name}
 </span>
             {e.externalUrl && (
-              <ExternalLink size={16} className="text-gray-400 group-hover:text-blue-500 transition-colors duration-300" strokeWidth={1.5} />
+              <ExternalLink size={16} className="!text-gray-400 group-hover:!text-blue-500 transition-colors duration-300" strokeWidth={1.5} />
             )}
           </div>
           
@@ -105,8 +105,8 @@ export default function EventCard({ e }: { e: Event }) {
           <h3
             className="
               font-bold text-xl leading-tight
-              text-gray-900 dark:text-white
-              group-hover:text-blue-600 dark:group-hover:text-blue-400
+              !text-gray-900 dark:!text-white
+              group-hover:!text-blue-600 dark:group-hover:!text-blue-400
               transition-colors duration-300
               line-clamp-2
             "
@@ -116,7 +116,7 @@ export default function EventCard({ e }: { e: Event }) {
 
           {/* Summary */}
           {e.summary && (
-            <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed line-clamp-2">
+            <p className="!text-gray-600 dark:!text-gray-300 text-sm leading-relaxed line-clamp-2">
               {e.summary}
             </p>
           )}
@@ -125,7 +125,7 @@ export default function EventCard({ e }: { e: Event }) {
           <div
             className="
               flex items-center gap-6 text-sm
-              text-gray-600 dark:text-gray-100
+              !text-gray-600 dark:!text-gray-100
               pt-2
               border-t border-gray-300/50 dark:border-gray-600/40
             "


### PR DESCRIPTION
## 根本原因

PR #22では表面的な修正しかできず、問題が解決していませんでした。

**真の原因:**
`global.css`の`.card-link`に`color: inherit;`が指定されており、これがEventCard内の全テキスト色を親要素から継承させていました。その結果、Tailwindの`text-gray-900`や`dark:text-white`などのクラスが完全に無視されていました。

**影響範囲:**
- PCでもSPでも発生
- ライトモードでもダークモードでも発生
- EventCardのタイトル、概要、日付・時刻の全てで文字色が正しく表示されない

## 修正内容

### 1. global.css
```css
/* 修正前 */
.card-link {
  color: inherit;  /* ← これが原因！ */
  text-decoration: none;
}

/* 修正後 */
.card-link {
  text-decoration: none;  /* color: inherit を削除 */
}

.card-link > * {
  color: inherit;  /* 直接の子要素のみ継承 */
}
```

### 2. EventCard.tsx
全テキスト要素に`!important`を追加してCSS優先度を確保：

- **タイトル**: `!text-gray-900 dark:!text-white`
- **概要**: `!text-gray-600 dark:!text-gray-300`
- **日付・時刻**: `!text-gray-600 dark:!text-gray-100`
- **ExternalLinkアイコン**: `!text-gray-400`
- **プラットフォームバッジ**: `dark:text-*-200`（より明るく）

## 検証

- [x] ライトモード（PC）で文字が見える
- [x] ライトモード（SP）で文字が見える
- [x] ダークモード（PC）で文字が見える
- [ ] ダークモード（SP実機）で文字が見える（デプロイ後確認）

## 関連PR

- #20 - 最初の不完全な修正（不正な構文あり）
- #22 - 2回目の修正（根本原因未解決）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクター**
  * スタイル定義を改善しました。ダークモード、通常モード、ホバー状態を含むすべての表示パターンで、色のスタイルがより確実に適用されるようになります。複数のUIコンポーネント間での色の表現の一貫性が強化されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->