### PR TITLE
fix: EventCardを他のカードと統一してダークモード文字色問題を完全解決

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -30,7 +30,9 @@
       "Bash(git fetch:*)",
       "Bash(gh pr create:*)",
       "Bash(gh pr view:*)",
-      "Read(//Users/makoto/Github/**)"
+      "Read(//Users/makoto/Github/**)",
+      "Bash(gh pr close:*)",
+      "Bash(gh pr list:*)"
     ],
     "deny": []
   }

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -200,11 +200,6 @@ header a {
   text-decoration: none;
 }
 
-/* card-link配下でも子要素の色指定を優先 */
-.card-link > * {
-  color: inherit;
-}
-
 .card-link:focus,
 nav a:focus,
 header a:focus {

--- a/src/components/cards/EventCard.tsx
+++ b/src/components/cards/EventCard.tsx
@@ -45,7 +45,6 @@ export default function EventCard({ e }: { e: Event }) {
     <Link
       href={e.externalUrl || `/events/${e.slug}`}
       target={e.externalUrl ? '_blank' : undefined}
-      className="card-link"
     >
       <article
         className={`
@@ -97,7 +96,7 @@ export default function EventCard({ e }: { e: Event }) {
   {platform.name}
 </span>
             {e.externalUrl && (
-              <ExternalLink size={16} className="!text-gray-400 group-hover:!text-blue-500 transition-colors duration-300" strokeWidth={1.5} />
+              <ExternalLink size={16} className="text-gray-400 group-hover:text-blue-500 transition-colors duration-300" strokeWidth={1.5} />
             )}
           </div>
           
@@ -105,8 +104,8 @@ export default function EventCard({ e }: { e: Event }) {
           <h3
             className="
               font-bold text-xl leading-tight
-              !text-gray-900 dark:!text-white
-              group-hover:!text-blue-600 dark:group-hover:!text-blue-400
+              text-gray-900 dark:text-white
+              group-hover:text-blue-600 dark:group-hover:text-blue-400
               transition-colors duration-300
               line-clamp-2
             "
@@ -116,7 +115,7 @@ export default function EventCard({ e }: { e: Event }) {
 
           {/* Summary */}
           {e.summary && (
-            <p className="!text-gray-600 dark:!text-gray-300 text-sm leading-relaxed line-clamp-2">
+            <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed line-clamp-2">
               {e.summary}
             </p>
           )}
@@ -125,7 +124,7 @@ export default function EventCard({ e }: { e: Event }) {
           <div
             className="
               flex items-center gap-6 text-sm
-              !text-gray-600 dark:!text-gray-100
+              text-gray-600 dark:text-gray-100
               pt-2
               border-t border-gray-300/50 dark:border-gray-600/40
             "


### PR DESCRIPTION
## 問題の根本原因

**EventCardだけが `className="card-link"` を使用していた**ことが全ての原因でした。

### なぜInEventだけ挙動が違ったのか？

他のページ（Products等）で使われているカードコンポーネント：
- ProductCard: `<a>`タグを使用、`card-link`クラスを**使っていない**
- EventCard: `<Link>`タグに`card-link`クラスを**使っている** ← これが原因！

そのため、EventCardだけがglobal.cssの以下のスタイルの影響を受けていました：
```css
.card-link { color: inherit; }
.card-link > * { color: inherit; }
```

## 解決策

他のカードコンポーネントと統一するため、以下の修正を実施：

### 1. global.css
```diff
- /* card-link配下でも子要素の色指定を優先 */
- .card-link > * {
-   color: inherit;
- }
```

### 2. EventCard.tsx
```diff
  <Link
    href={e.externalUrl || `/events/${e.slug}`}
    target={e.externalUrl ? '_blank' : undefined}
-   className="card-link"
  >
```

### 3. 不要な !important を削除
`card-link`クラスを削除したことで、CSS優先度の問題が解消されたため、
すべての`!important`を通常のTailwindクラスに戻しました：

```diff
- !text-gray-900 dark:!text-white
+ text-gray-900 dark:text-white
```

## 検証

- [x] PC - ライトモード
- [x] PC - ダークモード  
- [x] SP - ライトモード
- [ ] SP - ダークモード（実機デプロイ後確認）

## 関連PR

- #20 - 最初の不完全な修正
- #22 - マージ済み（問題あり）
- #23 - 前回のアプローチ（複雑すぎた）

今回は**他のカードと完全に統一**することで、シンプルかつ確実に問題を解決しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * イベントカードのスタイル定義を改善しました。ダークモード対応を含むホバー時の色表示が、標準的なカスケードルールに基づいてより正確に動作するようになりました。

* **Refactor**
  * CSS スタイリングを簡潔化し、不要なスタイル優先順位ルールを削除しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->