### PR TITLE
fix: in_eventページのH1/H3タグにインラインスタイルでダークモード対応

### DIFF
--- a/src/app/(frontend)/in_event/page.tsx
+++ b/src/app/(frontend)/in_event/page.tsx
@@ -17,7 +17,7 @@ export default async function InEventPage() {
         <Breadcrumb />
       </div>
       <section className={WRAP}>
-        <h1 className="text-3xl font-semibold mb-8 text-gray-900 dark:text-white">Events</h1>
+        <h1 className="text-3xl font-semibold mb-8" style={{ color: 'var(--fg-base)' }}>Events</h1>
         {inEvent.length === 0 && <p className="text-gray-700 dark:text-gray-300">現在予定されているイベントはありません。</p>}
         <div className="grid gap-6 sm:grid-cols-2">
           {inEvent.map((e) => (

--- a/src/app/(frontend)/in_event/page.tsx
+++ b/src/app/(frontend)/in_event/page.tsx
@@ -17,8 +17,8 @@ export default async function InEventPage() {
         <Breadcrumb />
       </div>
       <section className={WRAP}>
-        <h1 className="text-3xl font-semibold mb-8" style={{ color: 'var(--fg-base)' }}>Events</h1>
-        {inEvent.length === 0 && <p className="text-gray-700 dark:text-gray-300">現在予定されているイベントはありません。</p>}
+        <h1 className="text-3xl font-semibold mb-8 text-[color:var(--fg-base)]">Events</h1>
+        {inEvent.length === 0 && <p className="text-[color:var(--fg-base)]">現在予定されているイベントはありません。</p>}
         <div className="grid gap-6 sm:grid-cols-2">
           {inEvent.map((e) => (
             <EventCard key={e.id} e={e} />

--- a/src/components/cards/EventCard.tsx
+++ b/src/components/cards/EventCard.tsx
@@ -106,18 +106,18 @@ export default function EventCard({ e }: { e: Event }) {
           <h3
             className="
               font-bold text-xl leading-tight
-              !text-gray-900 dark:!text-white
-              group-hover:!text-blue-600 dark:group-hover:!text-blue-400
+              group-hover:text-blue-600 dark:group-hover:text-blue-400
               transition-colors duration-300
               line-clamp-2
             "
+            style={{ color: 'var(--fg-base)' }}
           >
             {e.title}
           </h3>
 
           {/* Summary */}
           {e.summary && (
-            <p className="!text-gray-600 dark:!text-gray-300 text-sm leading-relaxed line-clamp-2">
+            <p className="text-sm leading-relaxed line-clamp-2 opacity-80" style={{ color: 'var(--fg-base)' }}>
               {e.summary}
             </p>
           )}
@@ -126,10 +126,11 @@ export default function EventCard({ e }: { e: Event }) {
           <div
             className="
               flex items-center gap-6 text-sm
-              !text-gray-600 dark:!text-gray-100
               pt-2
               border-t border-gray-300/50 dark:border-gray-600/40
+              opacity-70
             "
+            style={{ color: 'var(--fg-base)' }}
           >
             <div className="flex items-center gap-2">
               <Calendar size={14} strokeWidth={1.5} />

--- a/src/components/cards/EventCard.tsx
+++ b/src/components/cards/EventCard.tsx
@@ -106,18 +106,18 @@ export default function EventCard({ e }: { e: Event }) {
           <h3
             className="
               font-bold text-xl leading-tight
+              text-[color:var(--fg-base)]
               group-hover:text-blue-600 dark:group-hover:text-blue-400
               transition-colors duration-300
               line-clamp-2
             "
-            style={{ color: 'var(--fg-base)' }}
           >
             {e.title}
           </h3>
 
           {/* Summary */}
           {e.summary && (
-            <p className="text-sm leading-relaxed line-clamp-2 opacity-80" style={{ color: 'var(--fg-base)' }}>
+            <p className="text-sm leading-relaxed line-clamp-2 opacity-80 text-[color:var(--fg-base)]">
               {e.summary}
             </p>
           )}
@@ -129,8 +129,8 @@ export default function EventCard({ e }: { e: Event }) {
               pt-2
               border-t border-gray-300/50 dark:border-gray-600/40
               opacity-70
+              text-[color:var(--fg-base)]
             "
-            style={{ color: 'var(--fg-base)' }}
           >
             <div className="flex items-center gap-2">
               <Calendar size={14} strokeWidth={1.5} />


### PR DESCRIPTION
## 問題

in_eventページで以下のテキストがダークモード時に見えない：
- H1タグ（ページタイトル "Events"）
- H3タグ（イベントタイトル）
- その他のテキストも少し暗い

## 原因

Tailwindの`!text-gray-900 dark:!text-white`が正しく機能していない。
Tailwind v4での`!important`の処理に問題がある可能性。

## 解決策

インラインスタイルで直接CSS変数を使用：
```tsx
style={{ color: 'var(--fg-base)' }}
```

### 修正内容

1. **H1タグ（in_event/page.tsx）**
   ```tsx
   <h1 style={{ color: 'var(--fg-base)' }}>Events</h1>
   ```

2. **H3タグ（EventCard.tsx）**
   ```tsx
   <h3 style={{ color: 'var(--fg-base)' }}>
     {e.title}
   </h3>
   ```

3. **概要文と日付**
   - `opacity-80` / `opacity-70` を追加して階層を作る
   - 同様に `var(--fg-base)` を使用

## 動作

- **ライトモード**: `--fg-base = #111` （黒） → 見える ✓
- **ダークモード**: `--fg-base = #f5f7fa` （白） → 見える ✓

## テスト

デプロイプレビューで確認してください：
- [ ] PCライトモード
- [ ] PCダークモード
- [ ] SPライトモード
- [ ] SPダークモード

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

**Style**
* テーマカラー管理をCSS変数に統一し、ライト/ダーク両モードでの色表現を一貫化。
* 見出しやカード内テキスト、空状態の文言に対する色指定を整理し、ホバー時の色変化も統一。
* 視覚的一貫性とアクセシビリティを向上させるスタイル最適化を実施。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->