### PR TITLE
fix+feat: いいね反映修正・UI/UX抜本改善・SEO全面強化

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -12,4 +12,40 @@ export default {
       },
     ],
   },
+  // 動的レンダリングのページはビルド成果物から検出されないため明示的に登録する
+  additionalPaths: async (config) => {
+    const staticPaths = [
+      '/timeline',
+      '/posts',
+      '/gallery',
+      '/products',
+      '/profile',
+      '/in_event',
+    ]
+    const results = await Promise.all(
+      staticPaths.map((path) => config.transform(config, path)),
+    )
+
+    // ブログ記事の個別ページ（DBからslugを取得。失敗してもビルドは止めない）
+    try {
+      const { Pool } = await import('pg')
+      const pool = new Pool({ connectionString: process.env.POSTGRES_URL })
+      const { rows } = await pool.query(
+        'SELECT slug, updated_at FROM blog_posts WHERE slug IS NOT NULL',
+      )
+      await pool.end()
+      for (const row of rows) {
+        results.push({
+          loc: `/posts/${row.slug}`,
+          lastmod: row.updated_at ? new Date(row.updated_at).toISOString() : undefined,
+          changefreq: 'weekly',
+          priority: 0.8,
+        })
+      }
+    } catch (error) {
+      console.warn('[next-sitemap] ブログslugの取得に失敗:', error?.message)
+    }
+
+    return results.filter(Boolean)
+  },
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,14 +20,17 @@ const nextConfig = {
   },
 
   async headers() {
+    // NOTE: Next.js は同一パスに同一キーのヘッダーが複数マッチした場合「後勝ち」なので、
+    // ブランケットルールを先頭に置き、静的アセットの長期キャッシュを最後に置く
     return [
-      // Long-term cache for Next.js static assets
+      // HTMLはブラウザに再検証させ、いいね数などの更新を即時反映する
+      // （no-store ではなく no-cache なので bfcache は維持される）
       {
-        source: '/_next/static/:path*',
+        source: '/:path*',
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable',
+            value: 'no-cache',
           },
         ],
       },
@@ -49,13 +52,13 @@ const nextConfig = {
           },
         ],
       },
-      // Allow bfcache by avoiding no-store on HTML; short cache for page data
+      // Long-term cache for Next.js static assets（最後に置いてブランケットを上書き）
       {
-        source: '/:path*',
+        source: '/_next/static/:path*',
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, max-age=600',
+            value: 'public, max-age=31536000, immutable',
           },
         ],
       },

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://iwabuchi-makoto.com/letter</loc><lastmod>2026-07-03T16:20:15.626Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com</loc><lastmod>2026-07-03T16:20:15.626Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/letter</loc><lastmod>2026-07-03T16:38:57.713Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com</loc><lastmod>2026-07-03T16:38:57.713Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://iwabuchi-makoto.com/letter</loc><lastmod>2026-07-03T16:38:57.713Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com</loc><lastmod>2026-07-03T16:38:57.713Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/letter</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/timeline</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/posts</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/gallery</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/products</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/profile</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/in_event</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/(frontend)/gallery/page.tsx
+++ b/src/app/(frontend)/gallery/page.tsx
@@ -11,12 +11,12 @@ export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 export const metadata: Metadata = {
-  title: 'ギャラリー | いわぶちまこと',
+  title: 'ギャラリー | 岩渕誠（いわぶちまこと）',
   description: '岩渕誠の写真ギャラリー。日常の風景や旅行の思い出、気になる瞬間を切り取った写真を公開しています。',
   keywords: ['ギャラリー', '写真', '岩渕誠', 'いわぶちまこと', '日常', '風景', '旅行'],
   authors: [{ name: 'いわぶちまこと' }],
   openGraph: {
-    title: 'ギャラリー | いわぶちまこと',
+    title: 'ギャラリー | 岩渕誠（いわぶちまこと）',
     description: '岩渕誠の写真ギャラリー。日常の風景や旅行の思い出、気になる瞬間を切り取った写真を公開しています。',
     url: 'https://iwabuchi-makoto.com/gallery',
     siteName: 'いわぶちまこと',
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'ギャラリー | いわぶちまこと',
+    title: 'ギャラリー | 岩渕誠（いわぶちまこと）',
     description: '岩渕誠の写真ギャラリー。日常の風景や旅行の思い出、気になる瞬間を切り取った写真を公開しています。',
     images: ['/myicon.png'],
   },
@@ -53,7 +53,7 @@ export default async function GalleryPage() {
   return (
     <main className="min-h-screen flex flex-col">
       {/* パンくず */}
-      <div className="mt-10 text-gray-400 text-left">
+      <div className="mx-auto w-full max-w-[58rem] px-5 sm:px-8 pt-6">
         <Breadcrumb />
       </div>
 

--- a/src/app/(frontend)/in_event/page.tsx
+++ b/src/app/(frontend)/in_event/page.tsx
@@ -2,7 +2,7 @@ import { fetchInEvent } from '@/lib/fetchInEvent'
 import EventCard from '@/components/cards/EventCard'
 import Breadcrumb from '@/components/layout/Breadcrumb'
 
-export const metadata = { title: 'イベント一覧 - いわぶちまこと' }
+export const metadata = { title: 'イベント一覧 | 岩渕誠（いわぶちまこと）' }
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
@@ -13,7 +13,7 @@ export default async function InEventPage() {
 
   return (
     <main className="min-h-screen flex flex-col bg-[color:var(--bg-base)]">
-      <div className="mt-10 text-gray-400 text-left">
+      <div className="mx-auto w-full max-w-[58rem] px-5 sm:px-8 pt-6">
         <Breadcrumb />
       </div>
       <section className={WRAP}>

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -3,16 +3,31 @@ import '../global.css'
 import type { Metadata } from 'next'
 import React from 'react'
 import GlassNav from '@/components/layout/GlassNav'
+import SiteFooter from '@/components/layout/SiteFooter'
 import { toCFUrl } from '@/lib/cfUrl'
 import { Providers } from '@/components/Providers'
 
 export const metadata: Metadata = {
-  title: 'いわぶち | ライフログ',
-  description: 'いわぶちの個人サイト。日記、写真、制作ログ、イベント記録などの日々の記録を残しています。',
-  keywords: ['いわぶち', 'ライフログ', '日記', '写真', 'ブログ', 'ギャラリー'],
-  authors: [{ name: 'いわぶち' }],
-  creator: 'いわぶち',
-  publisher: 'いわぶち',
+  title: {
+    default: '岩渕誠（いわぶちまこと） | ライフログ',
+    template: '%s | 岩渕誠（いわぶちまこと）',
+  },
+  description:
+    '岩渕誠（いわぶちまこと）の個人サイト。日記、写真、制作ログ、イベント記録などの日々の記録を残しています。',
+  keywords: [
+    '岩渕誠',
+    'いわぶちまこと',
+    'Makoto Iwabuchi',
+    'ライフログ',
+    '日記',
+    '写真',
+    'ブログ',
+    'ギャラリー',
+    '制作ログ',
+  ],
+  authors: [{ name: '岩渕誠', url: 'https://iwabuchi-makoto.com/profile' }],
+  creator: '岩渕誠（いわぶちまこと）',
+  publisher: '岩渕誠（いわぶちまこと）',
   formatDetection: {
     email: false,
     address: false,
@@ -33,8 +48,9 @@ export const metadata: Metadata = {
     shortcut: '/myicon.png',
   },
   openGraph: {
-    title: 'いわぶち | ライフログ',
-    description: 'いわぶちの個人サイト。日記、写真、制作ログ、イベント記録などの日々の記録を残しています。',
+    title: '岩渕誠（いわぶちまこと） | ライフログ',
+    description:
+      '岩渕誠（いわぶちまこと）の個人サイト。日記、写真、制作ログ、イベント記録などの日々の記録を残しています。',
     url: 'https://iwabuchi-makoto.com', // 実際のドメインに変更してください
     siteName: 'いわぶち',
     locale: 'ja_JP',
@@ -50,8 +66,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'いわぶち | ライフログ',
-    description: 'いわぶちの個人サイト。日記、写真、制作ログ、イベント記録などの日々の記録を残しています。',
+    title: '岩渕誠（いわぶちまこと） | ライフログ',
+    description:
+      '岩渕誠（いわぶちまこと）の個人サイト。日記、写真、制作ログ、イベント記録などの日々の記録を残しています。',
     creator: '@iwabuchi', // 実際のTwitterアカウントに変更してください
     images: ['/myicon.png'], // サイトの代表写真を使用
   },
@@ -85,15 +102,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             __html: JSON.stringify({
               "@context": "https://schema.org",
               "@type": "Person",
+              "@id": "https://iwabuchi-makoto.com/#person",
               "name": "岩渕誠",
-              "alternateName": "いわぶちまこと",
+              "alternateName": ["いわぶちまこと", "Makoto Iwabuchi", "いわぶち"],
+              "givenName": "誠",
+              "familyName": "岩渕",
               "jobTitle": "ウェブエンジニア",
-              "description": "ウェブエンジニア・フロントエンド開発者として活動する岩渕誠のポートフォリオサイト",
+              "description": "ウェブエンジニアとして活動する岩渕誠（いわぶちまこと）の個人サイト。日記・写真・制作ログなどのライフログを公開している。",
               "url": "https://iwabuchi-makoto.com",
+              "mainEntityOfPage": "https://iwabuchi-makoto.com/profile",
               "image": "https://iwabuchi-makoto.com" + toCFUrl('/profile.jpg'),
               "sameAs": [
                 "https://github.com/Makoto041",
-                "https://instagram.com/makoto0140"
+                "https://instagram.com/makoto0140",
+                "https://x.com/613_kmk"
               ],
               "knowsAbout": [
                 "Web Development",
@@ -117,11 +139,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             __html: JSON.stringify({
               "@context": "https://schema.org",
               "@type": "WebSite",
-              "name": "いわぶちまこと | 個人ポートフォリオサイト",
-              "alternateName": "岩渕誠 ポートフォリオ",
+              "name": "岩渕誠（いわぶちまこと） | ライフログ",
+              "alternateName": ["いわぶちまこと ライフログ", "Makoto Iwabuchi"],
               "url": "https://iwabuchi-makoto.com",
-              "description": "岩渕誠のポートフォリオサイト。日記、ブログ、写真ギャラリーなど日々の活動や作品を公開しています。",
+              "description": "岩渕誠（いわぶちまこと）の個人サイト。日記、写真、制作ログ、イベント記録など日々の記録を公開しています。",
               "inLanguage": "ja-JP",
+              "publisher": { "@id": "https://iwabuchi-makoto.com/#person" },
               "author": {
                 "@type": "Person",
                 "name": "岩渕誠",
@@ -144,6 +167,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
           {/* ── 1カラムのメインコンテンツ（各ページが <main> を持つため div） ── */}
           <div className="min-h-screen">{children}</div>
+
+          {/* ── フッター ── */}
+          <SiteFooter />
 
           {/* Portal root for modals */}
           <div id="modal-root"></div>

--- a/src/app/(frontend)/letter/page.tsx
+++ b/src/app/(frontend)/letter/page.tsx
@@ -41,9 +41,9 @@ export default function LetterPage() {
 
   return (
     <main className="min-h-screen flex flex-col">
-      <div className="mt-10 text-gray-400 text-left">
+      <div className="mx-auto w-full max-w-[28rem] px-5 sm:px-8 pt-6">
         <Breadcrumb />
-      </div>
+        </div>
       <section className={WRAP}>
         <form onSubmit={handleSubmit} className={CARD}>
           <h1 className="text-2xl font-semibold mb-4">お便りを送る</h1>

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -16,11 +16,13 @@ import AdminLinks from '@/components/admin/AdminLinks'
 import type { TimelineDoc, MediaDoc } from '@/lib/payloadTypes'
 
 export const metadata = {
-  title: 'いわぶちまこと - ライフログ',
-  description: 'いわぶちまことの個人サイト。日記、写真、制作ログ、イベント記録など日々の記録を残しています。',
+  title: '岩渕誠（いわぶちまこと） | ライフログ',
+  description:
+    '岩渕誠（いわぶちまこと）の個人サイト。日記、写真、制作ログ、イベント記録など日々の記録をタイムラインで残しています。',
   openGraph: {
-    title: 'いわぶちまこと - ライフログ',
-    description: 'いわぶちまことの個人サイト。日記、写真、制作ログ、イベント記録など日々の記録を残しています。',
+    title: '岩渕誠（いわぶちまこと） | ライフログ',
+    description:
+      '岩渕誠（いわぶちまこと）の個人サイト。日記、写真、制作ログ、イベント記録など日々の記録をタイムラインで残しています。',
     url: 'https://iwabuchi-makoto.com',
     siteName: 'いわぶちまこと',
     locale: 'ja_JP',
@@ -36,14 +38,15 @@ export const metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'いわぶちまこと - ライフログ',
-    description: 'いわぶちまことの個人サイト。日記、写真、制作ログ、イベント記録など日々の記録を残しています。',
+    title: '岩渕誠（いわぶちまこと） | ライフログ',
+    description:
+      '岩渕誠（いわぶちまこと）の個人サイト。日記、写真、制作ログ、イベント記録など日々の記録をタイムラインで残しています。',
     images: ['https://iwabuchi-makoto.com/myicon.png'],
   },
   alternates: {
     canonical: 'https://iwabuchi-makoto.com/',
   },
-  keywords: ['いわぶちまこと', '岩渕誠', 'ライフログ', '日記', '写真', '制作ログ'],
+  keywords: ['岩渕誠', 'いわぶちまこと', 'Makoto Iwabuchi', 'ライフログ', '日記', '写真', '制作ログ'],
 }
 
 /** タイムライン投稿からタグを集計（出現数順・最大12件） */
@@ -97,19 +100,29 @@ export default async function Home() {
   const photos = gallery.filter((g: MediaDoc) => g.url || g.sizes?.thumbnail?.url)
 
   return (
-    <main className="mx-auto w-full max-w-5xl px-4 pb-20 sm:px-6">
-      <h1 className="sr-only">いわぶちまこと ライフログ</h1>
+    <main className="mx-auto w-full max-w-5xl px-4 pb-12 sm:px-6">
       <Analytics />
+
+      {/* アイデンティティ（実名表記はSEOシグナルも兼ねる） */}
+      <header className="fade-in-up pt-10 pb-2">
+        <h1 className="text-xl font-semibold tracking-wide">
+          いわぶちまこと
+          <span className="ml-2 text-sm font-normal text-muted">岩渕誠 / Makoto Iwabuchi</span>
+        </h1>
+        <p className="mt-1.5 text-sm text-muted">
+          日々の記録・写真・制作物を残すライフログ
+        </p>
+      </header>
 
       {/* お知らせ（開催中イベントがある場合のみ） */}
       {activeEvent && (
-        <section className="pt-6">
+        <section className="pt-4">
           <ActiveEventCard event={activeEvent} cardClass="glass-card overflow-hidden" />
         </section>
       )}
 
       {/* タイムライン + サイドレール */}
-      <div className="grid gap-8 pt-8 lg:grid-cols-[minmax(0,1fr)_280px]">
+      <div className="grid gap-8 pt-6 lg:grid-cols-[minmax(0,1fr)_280px]">
         {/* メイン: タイムライン */}
         <section>
           <div className="mb-5 flex items-center justify-between">
@@ -123,10 +136,7 @@ export default async function Home() {
           <HomeTimeline timelineData={timeline} />
 
           <div className="mt-8 text-center">
-            <Link
-              href="/timeline"
-              className="glass inline-block rounded-full px-6 py-2 text-sm text-muted transition-opacity hover:opacity-75"
-            >
+            <Link href="/timeline" className="pill text-muted">
               もっと読む →
             </Link>
           </div>

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 
   if (!post) {
     return {
-      title: 'ページが見つかりません | いわぶちまこと',
+      title: 'ページが見つかりません | 岩渕誠（いわぶちまこと）',
       description: 'お探しのページは見つかりませんでした。',
     }
   }
@@ -120,9 +120,9 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <main className="min-h-screen flex flex-col">
-      <div className="mt-10 text-gray-400 text-left">
-            <Breadcrumb />
-    </div> 
+      <div className="mx-auto w-full max-w-[78rem] px-5 sm:px-8 pt-6">
+        <Breadcrumb />
+      </div>
       <section className={WRAP}>
           {post.coverImage?.url && (
             <div className="relative w-full h-64 mb-6">

--- a/src/app/(frontend)/posts/page.tsx
+++ b/src/app/(frontend)/posts/page.tsx
@@ -11,12 +11,12 @@ import PostsList from './PostsList'
 import PostsListLoading from './PostsListLoading'
 
 export const metadata: Metadata = {
-  title: 'ブログ | いわぶちまこと',
+  title: 'ブログ | 岩渕誠（いわぶちまこと）',
   description: '岩渕誠のブログ記事一覧。日々の考えや学習記録、技術的な話題について書き留めています。',
   keywords: ['ブログ', '岩渕誠', 'いわぶちまこと', '技術', '学習', '考え'],
   authors: [{ name: 'いわぶちまこと' }],
   openGraph: {
-    title: 'ブログ | いわぶちまこと',
+    title: 'ブログ | 岩渕誠（いわぶちまこと）',
     description: '岩渕誠のブログ記事一覧。日々の考えや学習記録、技術的な話題について書き留めています。',
     url: 'https://iwabuchi-makoto.com/posts',
     siteName: 'いわぶちまこと',
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'ブログ | いわぶちまこと',
+    title: 'ブログ | 岩渕誠（いわぶちまこと）',
     description: '岩渕誠のブログ記事一覧。日々の考えや学習記録、技術的な話題について書き留めています。',
     images: ['/myicon.png'],
   },
@@ -50,7 +50,7 @@ export default async function BlogPage() {
 
   return (
     <main className="min-h-screen flex flex-col">
-      <div className="mt-10 text-gray-400 text-left">
+      <div className="mx-auto w-full max-w-[58rem] px-5 sm:px-8 pt-6">
         <Breadcrumb />
       </div>
       <section className={WRAP}>

--- a/src/app/(frontend)/products/page.tsx
+++ b/src/app/(frontend)/products/page.tsx
@@ -4,12 +4,12 @@ import ProductCard from '@/components/cards/ProductCard'
 import Breadcrumb from '@/components/layout/Breadcrumb'
 
 export const metadata: Metadata = {
-  title: 'プロダクト | いわぶちまこと',
+  title: 'プロダクト | 岩渕誠（いわぶちまこと）',
   description: '岩渕誠が開発・制作したプロダクトの一覧。Webアプリケーション、ツール、サービスなどを公開しています。',
   keywords: ['プロダクト', '制作物', '岩渕誠', 'いわぶちまこと', 'Webアプリ', 'ツール', 'サービス'],
   authors: [{ name: 'いわぶちまこと' }],
   openGraph: {
-    title: 'プロダクト | いわぶちまこと',
+    title: 'プロダクト | 岩渕誠（いわぶちまこと）',
     description: '岩渕誠が開発・制作したプロダクトの一覧。Webアプリケーション、ツール、サービスなどを公開しています。',
     url: 'https://iwabuchi-makoto.com/products',
     siteName: 'いわぶちまこと',
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'プロダクト | いわぶちまこと',
+    title: 'プロダクト | 岩渕誠（いわぶちまこと）',
     description: '岩渕誠が開発・制作したプロダクトの一覧。Webアプリケーション、ツール、サービスなどを公開しています。',
     images: ['/myicon.png'],
   },
@@ -44,7 +44,7 @@ export default async function ProductsPage() {
 
   return (
     <main className="min-h-screen flex flex-col">
-      <div className="mt-10 text-gray-400 text-left">
+      <div className="mx-auto w-full max-w-[58rem] px-5 sm:px-8 pt-6">
         <Breadcrumb />
       </div>
       <section className={WRAP}>

--- a/src/app/(frontend)/profile/page.tsx
+++ b/src/app/(frontend)/profile/page.tsx
@@ -63,7 +63,7 @@ export async function generateMetadata(): Promise<Metadata> {
     console.error('Failed to generate profile metadata:', error)
     // フォールバック
     return {
-      title: 'プロフィール | いわぶちまこと',
+      title: 'プロフィール | 岩渕誠（いわぶちまこと）',
       description: '岩渕誠（いわぶちまこと）のプロフィールページ。ウェブエンジニア・フロントエンド開発者として活動しています。',
     }
   }
@@ -128,7 +128,7 @@ export default async function ProfilePage() {
     <>
       <link rel="preload" as="image" href={profileImageUrl} />
       <main className="min-h-screen flex flex-col">
-        <div className="mt-10 text-gray-400 text-left">
+        <div className="mx-auto w-full max-w-[28rem] px-5 sm:px-8 pt-6">
           <Breadcrumb />
         </div>
         <section className={WRAP}>

--- a/src/app/(frontend)/timeline/page.tsx
+++ b/src/app/(frontend)/timeline/page.tsx
@@ -10,12 +10,12 @@ export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 export const metadata: Metadata = {
-  title: 'タイムライン | いわぶちまこと',
+  title: 'タイムライン | 岩渕誠（いわぶちまこと）',
   description: '岩渕誠の日々の活動記録。リアルタイムで更新される思考の断片や日常の出来事を時系列で公開しています。',
   keywords: ['タイムライン', '日記', '岩渕誠', 'いわぶちまこと', '日常', '活動記録'],
   authors: [{ name: 'いわぶちまこと' }],
   openGraph: {
-    title: 'タイムライン | いわぶちまこと',
+    title: 'タイムライン | 岩渕誠（いわぶちまこと）',
     description: '岩渕誠の日々の活動記録。リアルタイムで更新される思考の断片や日常の出来事を時系列で公開しています。',
     url: 'https://iwabuchi-makoto.com/timeline',
     siteName: 'いわぶちまこと',
@@ -32,7 +32,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'タイムライン | いわぶちまこと',
+    title: 'タイムライン | 岩渕誠（いわぶちまこと）',
     description: '岩渕誠の日々の活動記録。リアルタイムで更新される思考の断片や日常の出来事を時系列で公開しています。',
     images: ['/myicon.png'],
   },
@@ -49,7 +49,7 @@ export default async function TimelinePage() {
 
   return (
     <main className="mx-auto w-full max-w-2xl px-4 pb-20 sm:px-6">
-      <div className="mt-6 text-muted">
+      <div className="pt-6">
         <Breadcrumb />
       </div>
 
@@ -65,10 +65,7 @@ export default async function TimelinePage() {
         <TimelineList initialTimeline={timeline} />
 
         <div className="mt-16 text-center">
-          <Link
-            href="/"
-            className="glass inline-block rounded-full px-6 py-2 text-sm text-muted transition-opacity hover:opacity-75"
-          >
+          <Link href="/" className="pill text-muted">
             ← TOPページへ
           </Link>
         </div>

--- a/src/app/api/timeline/[id]/like/route.ts
+++ b/src/app/api/timeline/[id]/like/route.ts
@@ -4,6 +4,7 @@
 // - httpOnly Cookie による重複いいね防止
 // - IPベースの簡易レート制限（サーバーレスのためベストエフォート）
 import { NextRequest, NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
 import { sql } from '@payloadcms/db-vercel-postgres'
 import { getPayloadClient } from '@/lib/payloadClient'
 
@@ -79,6 +80,10 @@ export async function POST(
     sql`UPDATE timeline SET likes = COALESCE(likes, 0) + 1 WHERE id = ${id} RETURNING likes`,
   )
   const likes = Number((result.rows?.[0] as { likes?: unknown } | undefined)?.likes ?? (doc.likes ?? 0) + 1)
+
+  // ISRキャッシュを無効化し、次回アクセスで最新のいいね数を反映させる
+  revalidatePath('/')
+  revalidatePath('/timeline')
 
   const res = NextResponse.json({ likes, alreadyLiked: false })
   const nextIds = [...likedIds, String(id)].slice(-COOKIE_MAX_IDS)

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -4,30 +4,35 @@
   src: url('/fonts/HigureGothic-Light.ttf') format('truetype');
   font-weight: 300;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Higure Gothic';
   src: url('/fonts/HigureGothic-Regular.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Higure Gothic';
   src: url('/fonts/HigureGothic-Medium.ttf') format('truetype');
   font-weight: 500;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Higure Gothic';
   src: url('/fonts/HigureGothic-Bold.ttf') format('truetype');
   font-weight: 700;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Higure Gothic';
   src: url('/fonts/HigureGothic-Black.ttf') format('truetype');
   font-weight: 900;
   font-style: normal;
+  font-display: swap;
 }
 
 /* ──────────────────────────────────────────────
@@ -68,6 +73,7 @@
 :root {
   --glass-surface: var(--glass-surface-light);
   --glass-border: var(--glass-border-light);
+  --glass-highlight: hsl(0 0% 100% / 0.6);
   --bg-base: var(--bg-light);
   --fg-base: var(--fg-light);
   --fg-muted: #64748b;
@@ -95,6 +101,7 @@
   :root:not(.light):not(.dark) {
     --glass-surface: var(--glass-surface-dark);
     --glass-border: var(--glass-border-dark);
+    --glass-highlight: hsl(0 0% 100% / 0.07);
     --bg-base: var(--bg-dark);
     --fg-base: var(--fg-dark);
     --fg-muted: #8a99ab;
@@ -119,6 +126,7 @@
 .light {
   --glass-surface: var(--glass-surface-light);
   --glass-border: var(--glass-border-light);
+  --glass-highlight: hsl(0 0% 100% / 0.6);
   --bg-base: var(--bg-light);
   --fg-base: var(--fg-light);
   --fg-muted: #64748b;
@@ -142,6 +150,7 @@
 .dark {
   --glass-surface: var(--glass-surface-dark);
   --glass-border: var(--glass-border-dark);
+  --glass-highlight: hsl(0 0% 100% / 0.07);
   --bg-base: var(--bg-dark);
   --fg-base: var(--fg-dark);
   --fg-muted: #8a99ab;
@@ -168,25 +177,32 @@
     @apply py-8 sm:py-12 lg:py-16;
   }
 
-  /* 基本のガラス面（ナビ・パネル用） */
+  /* 基本のガラス面（ナビ・パネル用）
+     上端のinsetハイライトと彩度ブーストで「液体ガラス」の質感を出す */
   .glass {
     @apply rounded-[var(--radius-m)]
            backdrop-blur-[var(--blur-m)]
+           backdrop-saturate-150
            bg-[color:var(--glass-surface)]
            border border-[color:var(--glass-border)];
 
-    box-shadow: var(--card-shadow);
+    box-shadow:
+      inset 0 1px 0 var(--glass-highlight),
+      var(--card-shadow);
   }
 
   /* タイムラインカード用：控えめなホバーだけ動く */
   .glass-card {
     @apply rounded-[var(--radius-m)]
            backdrop-blur-[var(--blur-m)]
+           backdrop-saturate-150
            border;
 
     background: var(--card-bg);
     border-color: var(--card-border);
-    box-shadow: var(--card-shadow);
+    box-shadow:
+      inset 0 1px 0 var(--glass-highlight),
+      var(--card-shadow);
     transition:
       background 0.25s ease,
       border-color 0.25s ease,
@@ -196,7 +212,9 @@
   .glass-card:hover {
     background: var(--card-bg-hover);
     border-color: var(--card-border-hover);
-    box-shadow: var(--card-shadow-hover);
+    box-shadow:
+      inset 0 1px 0 var(--glass-highlight),
+      var(--card-shadow-hover);
     transform: translateY(-1px);
   }
 
@@ -208,9 +226,70 @@
     color: var(--chip-fg);
   }
 
+  /* ガラス風ピル（リンク・CTA用） */
+  .pill {
+    @apply inline-flex items-center justify-center rounded-full px-6 py-2 text-sm;
+
+    backdrop-filter: blur(var(--blur-m)) saturate(1.5);
+    background: var(--glass-surface);
+    border: 1px solid var(--glass-border);
+    box-shadow:
+      inset 0 1px 0 var(--glass-highlight),
+      var(--card-shadow);
+    transition:
+      background 0.25s ease,
+      box-shadow 0.25s ease,
+      transform 0.25s ease;
+  }
+  .pill:hover {
+    background: var(--card-bg-hover);
+    box-shadow:
+      inset 0 1px 0 var(--glass-highlight),
+      var(--card-shadow-hover);
+    transform: translateY(-1px);
+  }
+
   /* 補助テキスト */
   .text-muted {
     color: var(--fg-muted);
+  }
+}
+
+/* === MOTION =================================== */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-in-up {
+  animation: fadeInUp 0.45s ease both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-in-up {
+    animation: none;
+  }
+
+  .glass-card,
+  .pill {
+    transition: none;
   }
 }
 
@@ -223,6 +302,33 @@ body {
   background-color: var(--bg-base);
   background-image: var(--page-gradient);
   background-attachment: fixed;
+}
+
+/* ごく薄いアンビエント光彩（ガラス面に映り込む「奥行き」用。
+   装飾は最小限に留め、コンテンツを主役にする） */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(38rem 26rem at 82% -6%, hsl(206 70% 85% / 0.35), transparent 70%),
+    radial-gradient(30rem 22rem at -8% 30%, hsl(196 60% 88% / 0.28), transparent 70%);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not(.light):not(.dark) body::before {
+    background:
+      radial-gradient(38rem 26rem at 82% -6%, hsl(212 60% 30% / 0.16), transparent 70%),
+      radial-gradient(30rem 22rem at -8% 30%, hsl(196 60% 25% / 0.12), transparent 70%);
+  }
+}
+
+.dark body::before {
+  background:
+    radial-gradient(38rem 26rem at 82% -6%, hsl(212 60% 30% / 0.16), transparent 70%),
+    radial-gradient(30rem 22rem at -8% 30%, hsl(196 60% 25% / 0.12), transparent 70%);
 }
 
 /* コンテンツ内のリンクはアクセシブルに保つ */

--- a/src/collections/Users.ts
+++ b/src/collections/Users.ts
@@ -1,8 +1,24 @@
 import { CollectionConfig } from 'payload'
+import { adminOnly } from '@/lib/access'
 
 export const Users: CollectionConfig = {
   slug: 'users',
-  auth: true,
+  auth: {
+    // ブルートフォース対策：5回失敗で10分間ロック
+    maxLoginAttempts: 5,
+    lockTime: 10 * 60 * 1000,
+    cookies: {
+      sameSite: 'Lax',
+      secure: process.env.NODE_ENV === 'production',
+    },
+  },
+  access: {
+    // ユーザー情報の閲覧・管理は認証済みユーザーのみ
+    read: adminOnly,
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
+  },
   admin: {
     useAsTitle: 'email',
   },

--- a/src/components/admin/AdminLinks.tsx
+++ b/src/components/admin/AdminLinks.tsx
@@ -29,7 +29,8 @@ export default function AdminLinks() {
   if (!isAdmin) return null
 
   return (
-    <span className="inline-flex items-center gap-3 text-xs text-muted">
+    // フェードインで出現させ、遅延表示によるちらつきを抑える
+    <span className="inline-flex animate-[fadeIn_.3s_ease] items-center gap-3 text-xs text-muted">
       {/* PayloadCMS Admin は別レイアウトのため、フルページ遷移させる */}
       {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
       <a

--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -30,12 +30,26 @@ export default function Breadcrumb({
 
   const crumbs = items && items.length > 0 ? items : autoItems
 
+  // 検索結果にパンくずを表示させるための構造化データ
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: crumbs.map((crumb, idx) => ({
+      '@type': 'ListItem',
+      position: idx + 1,
+      name: crumb.label,
+      item: `https://iwabuchi-makoto.com${crumb.href === '/' ? '' : crumb.href}`,
+    })),
+  }
+
   return (
-    <nav
-      aria-label="Breadcrumb"
-      className="mx-auto w-full max-w-[80rem] px-5 sm:px-8 text-sm text-gray-400 mb-4"
-    >
-      <ol className="flex flex-wrap gap-1">
+    // コンテナはページ側に任せる（独自の max-w/px を持つと本文と整列しないため）
+    <nav aria-label="Breadcrumb" className="text-[13px] text-muted">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <ol className="flex flex-wrap items-center gap-1">
         {crumbs.map((crumb, idx) => {
           const isLast = idx === crumbs.length - 1
           return (
@@ -44,7 +58,9 @@ export default function Breadcrumb({
               <Link
                 href={crumb.href}
                 aria-current={isLast ? 'page' : undefined}
-                className={`text-gray-400 hover:underline hover:text-gray-600 transition ${isLast ? 'font-medium' : ''}`}
+                className={`transition-opacity hover:opacity-70 ${
+                  isLast ? 'font-medium opacity-100' : 'opacity-80'
+                }`}
               >
                 {crumb.label}
               </Link>

--- a/src/components/layout/GlassNav.tsx
+++ b/src/components/layout/GlassNav.tsx
@@ -35,7 +35,7 @@ export default function GlassNav() {
         </Link>
 
         {/* デスクトップナビ */}
-        <nav className="hidden items-center gap-5 md:flex">
+        <nav className="hidden items-center gap-1.5 md:flex">
           {NAV.map(({ href, label }) => {
             const isActive = pathname === href || pathname?.startsWith(href + '/')
             return (
@@ -43,17 +43,19 @@ export default function GlassNav() {
                 key={href}
                 href={href}
                 className={clsx(
-                  'text-[13px] tracking-wide transition-opacity',
+                  'rounded-full px-3 py-1 text-[13px] tracking-wide transition-all duration-200',
                   isActive
-                    ? 'font-semibold opacity-100 text-[color:var(--accent)]'
-                    : 'opacity-65 hover:opacity-100',
+                    ? 'bg-[color:var(--chip-bg)] font-semibold text-[color:var(--chip-fg)]'
+                    : 'opacity-65 hover:bg-[color:var(--chip-bg)] hover:opacity-100',
                 )}
               >
                 {label}
               </Link>
             )
           })}
-          <ThemeToggle />
+          <span className="ml-2">
+            <ThemeToggle />
+          </span>
         </nav>
 
         {/* モバイル：テーマ切替＋ハンバーガー */}
@@ -92,7 +94,7 @@ export default function GlassNav() {
       {open && (
         <nav
           id="mobile-menu"
-          className="glass mx-auto mt-2 max-w-4xl rounded-2xl p-4 md:hidden"
+          className="glass fade-in-up mx-auto mt-2 max-w-4xl rounded-2xl p-4 md:hidden"
         >
           <ul className="flex flex-col gap-1">
             {NAV.map(({ href, label }) => {
@@ -105,7 +107,7 @@ export default function GlassNav() {
                     className={clsx(
                       'block rounded-xl px-3 py-2 text-sm tracking-wide transition-colors',
                       isActive
-                        ? 'font-semibold text-[color:var(--accent)]'
+                        ? 'bg-[color:var(--chip-bg)] font-semibold text-[color:var(--chip-fg)]'
                         : 'opacity-75 hover:opacity-100',
                     )}
                   >

--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -1,0 +1,73 @@
+// src/components/layout/SiteFooter.tsx
+// グラス風フッター（実名表記はSEO・E-E-A-Tシグナルも兼ねる）
+import Link from 'next/link'
+
+const FOOTER_NAV = [
+  { label: 'Timeline', href: '/timeline' },
+  { label: 'Posts', href: '/posts' },
+  { label: 'Gallery', href: '/gallery' },
+  { label: 'Products', href: '/products' },
+  { label: 'Profile', href: '/profile' },
+  { label: 'Letter', href: '/letter' },
+] as const
+
+export default function SiteFooter() {
+  return (
+    <footer className="mx-auto mt-8 w-full max-w-5xl px-4 pb-8 sm:px-6">
+      <div className="glass rounded-2xl px-6 py-6">
+        <div className="flex flex-col items-center gap-5 sm:flex-row sm:items-start sm:justify-between">
+          <div className="text-center sm:text-left">
+            <p className="text-sm font-semibold tracking-wide">
+              岩渕誠<span className="ml-1.5 text-xs font-normal text-muted">いわぶちまこと / Makoto Iwabuchi</span>
+            </p>
+            <p className="mt-1.5 text-xs leading-relaxed text-muted">
+              日々の記録・写真・制作物を残す個人のライフログサイト
+            </p>
+            <div className="mt-3 flex justify-center gap-4 text-xs sm:justify-start">
+              <a
+                href="https://x.com/613_kmk"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted transition-opacity hover:opacity-70"
+              >
+                X
+              </a>
+              <a
+                href="https://instagram.com/makoto0140"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted transition-opacity hover:opacity-70"
+              >
+                Instagram
+              </a>
+              <a
+                href="https://github.com/Makoto041"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted transition-opacity hover:opacity-70"
+              >
+                GitHub
+              </a>
+            </div>
+          </div>
+
+          <nav aria-label="フッターナビゲーション" className="grid grid-cols-3 gap-x-6 gap-y-2 text-xs sm:grid-cols-2">
+            {FOOTER_NAV.map(({ label, href }) => (
+              <Link
+                key={href}
+                href={href}
+                className="text-muted transition-opacity hover:opacity-70"
+              >
+                {label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+
+        <p className="mt-5 border-t border-[color:var(--glass-border)] pt-4 text-center text-[11px] text-muted sm:text-left">
+          © {new Date().getFullYear()} Makoto Iwabuchi
+        </p>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/timeline/TimelineCard.tsx
+++ b/src/components/timeline/TimelineCard.tsx
@@ -71,7 +71,7 @@ export default function TimelineCard({
   const relatedLinks = buildRelatedLinks(post)
 
   return (
-    <article className="glass-card p-5">
+    <article className="glass-card fade-in-up p-5">
       {/* ヘッダー: 投稿タイプ + 日時 */}
       <div className="mb-2 flex items-center gap-2.5">
         {typeLabel && <span className="chip">{typeLabel}</span>}

--- a/src/components/widgets/WeatherWidgetClient.tsx
+++ b/src/components/widgets/WeatherWidgetClient.tsx
@@ -1,8 +1,14 @@
 'use client'
 import nextDynamic from 'next/dynamic'
 
+// レイアウトシフト防止：ロード中も実物と同じ寸法のスケルトンを表示する
 const WeatherWidget = nextDynamic(() => import('@/components/widgets/WeatherWidget'), {
   ssr: false,
-  loading: () => null,
+  loading: () => (
+    <div
+      aria-hidden="true"
+      className="glass inline-flex h-[30px] w-44 animate-pulse items-center rounded-full px-3"
+    />
+  ),
 })
 export default WeatherWidget


### PR DESCRIPTION
## Summary

1. **いいね数が最大10分反映されない問題を修正**（ブラウザキャッシュ`max-age=600`が原因）
2. **UI/UXの抜本改善**：パンくずのずれ解消、CLS対策、Liquid Glassの質感強化、グラスフッター新設
3. **SEO全面強化**：「岩渕誠」「いわぶちまこと」での上位表示を狙った実名最適化
4. **Adminログインのブルートフォース対策**

## Changes

### 🐛 いいね反映修正
- `next.config`: 全ページの`Cache-Control: public, max-age=600`を`no-cache`に（bfcacheは維持）
- ルール順修正で`/_next/static`のimmutableキャッシュ上書きバグも解消（同一キーは後勝ち）
- いいねAPI成功時に`revalidatePath('/')`/`('/timeline')`でISRを即時無効化

### 🎨 UI/UX
- **パンくずのずれ解消**: Breadcrumb独自の`max-w-[80rem]`コンテナを廃止し、全8ページで本文コンテナと整列
- **CLS対策**: WeatherWidgetに同寸法スケルトン、AdminLinksにフェードイン
- **Liquid Glass質感**: insetハイライト+backdrop-saturate、アンビエント光彩、pillユーティリティ
- **ナビ**: アクティブページをピル表示、ホバーも同系
- **新設**: 実名入りグラスフッター、ホームのアイデンティティブロック（可視H1）
- カードにfadeInUp（`prefers-reduced-motion`対応）

### 🔍 SEO
- 全ページtitle「◯◯ | 岩渕誠（いわぶちまこと）」+ titleテンプレート
- Person JSON-LD拡充（alternateName複数形態・sameAs 3件・@id相互参照）
- BreadcrumbList構造化データ
- **sitemap修正**: 従来2ページのみ→全ページ+ブログ記事slugを登録
- font-display: swap、フッター実名表記（E-E-A-T）

### 🔒 セキュリティ
- Users auth: `maxLoginAttempts: 5` / `lockTime: 10分`（総当たり対策）
- Usersコレクションを認証済みのみに明示

## Test Plan
- [x] `pnpm build` 成功、sitemapに全8ページ登録を確認
- [x] 全ページ200、アイデンティティ/フッター/JSON-LD/ナビピルのレンダリング確認
- [x] いいねAPI: atomicインクリメント・重複防止・レート制限の動作確認済み
- [ ] Vercelプレビューでライト/ダーク両モードの見た目確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)