### PR TITLE
feat: SP表示崩れ修正・全ページ横幅統一・イベントカード刷新

### DIFF
--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://iwabuchi-makoto.com/letter</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/timeline</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/posts</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/gallery</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/products</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/profile</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/in_event</loc><lastmod>2026-07-03T16:48:45.199Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/letter</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/timeline</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/posts</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/gallery</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/products</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/profile</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/in_event</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://iwabuchi-makoto.com/letter</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/timeline</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/posts</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/gallery</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/products</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/profile</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/in_event</loc><lastmod>2026-07-03T17:07:26.758Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/letter</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/timeline</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/posts</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/gallery</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/products</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/profile</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/in_event</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/(frontend)/gallery/page.tsx
+++ b/src/app/(frontend)/gallery/page.tsx
@@ -53,12 +53,12 @@ export default async function GalleryPage() {
   return (
     <main className="min-h-screen flex flex-col">
       {/* パンくず */}
-      <div className="mx-auto w-full max-w-[58rem] px-5 sm:px-8 pt-6">
+      <div className="pt-6">
         <Breadcrumb />
       </div>
 
       {/* セクションラップ */}
-      <section className="mx-auto w-full max-w-[58rem] px-5 sm:px-8 section-pad">
+      <section className="section-pad">
         <div className="mb-6">
           <h1 className="text-3xl font-semibold">Gallery</h1>
         </div>

--- a/src/app/(frontend)/in_event/page.tsx
+++ b/src/app/(frontend)/in_event/page.tsx
@@ -6,18 +6,18 @@ export const metadata = { title: 'イベント一覧 | 岩渕誠（いわぶち�
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
-const WRAP = 'mx-auto w-full max-w-[58rem] px-5 sm:px-8 section-pad'
+const WRAP = 'section-pad'
 
 export default async function InEventPage() {
   const inEvent = await fetchInEvent()
 
   return (
     <main className="min-h-screen flex flex-col bg-[color:var(--bg-base)]">
-      <div className="mx-auto w-full max-w-[58rem] px-5 sm:px-8 pt-6">
+      <div className="pt-6">
         <Breadcrumb />
       </div>
       <section className={WRAP}>
-        <h1 className="text-3xl font-semibold mb-8 text-[color:var(--fg-base)]">Events</h1>
+        <h1 className="text-2xl font-semibold tracking-wide mb-8">Events</h1>
         {inEvent.length === 0 && <p className="text-[color:var(--fg-base)]">現在予定されているイベントはありません。</p>}
         <div className="grid gap-6 sm:grid-cols-2">
           {inEvent.map((e) => (

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -165,8 +165,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           {/* ── 上部グラスナビゲーション ── */}
           <GlassNav />
 
-          {/* ── 1カラムのメインコンテンツ（各ページが <main> を持つため div） ── */}
-          <div className="min-h-screen">{children}</div>
+          {/* ── 1カラムのメインコンテンツ（各ページが <main> を持つため div）
+               全ページ同一のコンテナ幅にすることで、ページ遷移時の横ずれを防ぐ ── */}
+          <div className="mx-auto min-h-screen w-full max-w-5xl px-4 sm:px-6">{children}</div>
 
           {/* ── フッター ── */}
           <SiteFooter />

--- a/src/app/(frontend)/letter/page.tsx
+++ b/src/app/(frontend)/letter/page.tsx
@@ -4,7 +4,7 @@
 import { useState } from 'react'
 import Breadcrumb from '@/components/layout/Breadcrumb'
 
-const WRAP = 'mx-auto w-full max-w-[28rem] px-5 sm:px-8 section-pad flex justify-center'
+const WRAP = 'mx-auto w-full max-w-[28rem] section-pad flex justify-center'
 const CARD = 'glass p-8 flex flex-col gap-4 w-full'
 
 export default function LetterPage() {
@@ -41,7 +41,7 @@ export default function LetterPage() {
 
   return (
     <main className="min-h-screen flex flex-col">
-      <div className="mx-auto w-full max-w-[28rem] px-5 sm:px-8 pt-6">
+      <div className="pt-6">
         <Breadcrumb />
         </div>
       <section className={WRAP}>

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -100,7 +100,7 @@ export default async function Home() {
   const photos = gallery.filter((g: MediaDoc) => g.url || g.sizes?.thumbnail?.url)
 
   return (
-    <main className="mx-auto w-full max-w-5xl px-4 pb-12 sm:px-6">
+    <main className="pb-12">
       <Analytics />
 
       {/* アイデンティティ（実名表記はSEOシグナルも兼ねる） */}
@@ -117,7 +117,7 @@ export default async function Home() {
       {/* お知らせ（開催中イベントがある場合のみ） */}
       {activeEvent && (
         <section className="pt-4">
-          <ActiveEventCard event={activeEvent} cardClass="glass-card overflow-hidden" />
+          <ActiveEventCard event={activeEvent} />
         </section>
       )}
 
@@ -125,7 +125,7 @@ export default async function Home() {
       <div className="grid gap-8 pt-6 lg:grid-cols-[minmax(0,1fr)_280px]">
         {/* メイン: タイムライン */}
         <section>
-          <div className="mb-5 flex items-center justify-between">
+          <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-baseline gap-3">
               <h2 className="text-lg font-semibold tracking-wide">Timeline</h2>
               <AdminLinks />

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -70,7 +70,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   }
 }
 
-const WRAP = 'mx-auto w-full max-w-[78rem] px-5 sm:px-8 section-pad'
+const WRAP = 'section-pad'
 
 export default async function PostPage({ params }: { params: Promise<{ slug: string }> }) {
   // Next.js v15+: params は Promise になっているので await して展開
@@ -120,7 +120,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <main className="min-h-screen flex flex-col">
-      <div className="mx-auto w-full max-w-[78rem] px-5 sm:px-8 pt-6">
+      <div className="pt-6">
         <Breadcrumb />
       </div>
       <section className={WRAP}>

--- a/src/app/(frontend)/posts/page.tsx
+++ b/src/app/(frontend)/posts/page.tsx
@@ -42,7 +42,7 @@ export const metadata: Metadata = {
   },
 }
 
-const WRAP = 'mx-auto w-full max-w-[58rem] px-5 sm:px-8 section-pad'
+const WRAP = 'section-pad'
 
 export default async function BlogPage() {
   // blogLimit: 10 件取得
@@ -50,11 +50,11 @@ export default async function BlogPage() {
 
   return (
     <main className="min-h-screen flex flex-col">
-      <div className="mx-auto w-full max-w-[58rem] px-5 sm:px-8 pt-6">
+      <div className="pt-6">
         <Breadcrumb />
       </div>
       <section className={WRAP}>
-        <h1 className="text-3xl font-semibold mb-2">Blog</h1>
+        <h1 className="text-2xl font-semibold tracking-wide mb-2">Blog</h1>
         <p className="mb-8 opacity-80">考えていることを書き留めておく場所</p>
         {/* Suspense でラップ！ */}
         <Suspense fallback={<PostsListLoading />}>

--- a/src/app/(frontend)/products/page.tsx
+++ b/src/app/(frontend)/products/page.tsx
@@ -37,18 +37,18 @@ export const metadata: Metadata = {
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
-const WRAP = 'mx-auto w-full max-w-[58rem] px-5 sm:px-8 section-pad'
+const WRAP = 'section-pad'
 
 export default async function ProductsPage() {
   const products = await fetchProducts()
 
   return (
     <main className="min-h-screen flex flex-col">
-      <div className="mx-auto w-full max-w-[58rem] px-5 sm:px-8 pt-6">
+      <div className="pt-6">
         <Breadcrumb />
       </div>
       <section className={WRAP}>
-        <h1 className="text-3xl font-semibold mb-8">Products</h1>
+        <h1 className="text-2xl font-semibold tracking-wide mb-8">Products</h1>
         {products.length === 0 && <p>まだ公開されていません。</p>}
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {products.map((p) => (

--- a/src/app/(frontend)/profile/page.tsx
+++ b/src/app/(frontend)/profile/page.tsx
@@ -69,7 +69,7 @@ export async function generateMetadata(): Promise<Metadata> {
   }
 }
 const WRAP =
-  'mx-auto w-full max-w-[28rem] px-5 sm:px-8 section-pad flex flex-col items-center text-center'
+  'mx-auto w-full max-w-[28rem] section-pad flex flex-col items-center text-center'
 const CARD = 'glass p-8 flex flex-col items-center'
 
 export default async function ProfilePage() {
@@ -128,7 +128,7 @@ export default async function ProfilePage() {
     <>
       <link rel="preload" as="image" href={profileImageUrl} />
       <main className="min-h-screen flex flex-col">
-        <div className="mx-auto w-full max-w-[28rem] px-5 sm:px-8 pt-6">
+        <div className="pt-6">
           <Breadcrumb />
         </div>
         <section className={WRAP}>

--- a/src/app/(frontend)/timeline/page.tsx
+++ b/src/app/(frontend)/timeline/page.tsx
@@ -48,13 +48,13 @@ export default async function TimelinePage() {
   })
 
   return (
-    <main className="mx-auto w-full max-w-2xl px-4 pb-20 sm:px-6">
+    <main className="mx-auto w-full max-w-2xl pb-20">
       <div className="pt-6">
         <Breadcrumb />
       </div>
 
       <section className="pt-6">
-        <div className="mb-6 flex items-center justify-between">
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-baseline gap-3">
             <h1 className="text-2xl font-semibold tracking-wide">Timeline</h1>
             <AdminLinks />

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -294,6 +294,12 @@
 }
 
 /* === BASE ===================================== */
+
+/* ページごとのスクロールバー有無で横位置がずれないよう常にガター確保 */
+html {
+  scrollbar-gutter: stable;
+}
+
 body {
   @apply text-[color:var(--fg-base)]
          antialiased selection:bg-(--accent)/25;

--- a/src/components/cards/ActiveEventCard.tsx
+++ b/src/components/cards/ActiveEventCard.tsx
@@ -1,214 +1,109 @@
-// src/components/ActiveEventCard.tsx
-import { Calendar, Clock, Bell } from 'lucide-react'
+// src/components/cards/ActiveEventCard.tsx
+// トップページのお知らせカード（予定/開催中）。
+// glass-cardベースの横型レイアウトで、開催中は赤リングで控えめに強調する
 import Image from 'next/image'
+import { Calendar, Clock, Bell } from 'lucide-react'
 import type { Event } from '@/payload-types'
 import { toCFUrl } from '@/lib/cfUrl'
-
-const platformConfig = {
-  twitch: {
-    name: 'Twitch',
-    badgeClass: 'bg-purple-50 dark:bg-purple-900/20 text-purple-700 dark:text-purple-300',
-    dotClass: 'bg-purple-500 dark:bg-purple-400',
-  },
-  youtube: {
-    name: 'YouTube',
-    badgeClass: 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300',
-    dotClass: 'bg-red-500 dark:bg-red-400',
-  },
-  nico: {
-    name: 'ニコニコ',
-    badgeClass: 'bg-orange-50 dark:bg-orange-900/20 text-orange-700 dark:text-orange-300',
-    dotClass: 'bg-orange-500 dark:bg-orange-400',
-  },
-  offline: {
-    name: '現地イベント',
-    badgeClass: 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300',
-    dotClass: 'bg-green-500 dark:bg-green-400',
-  },
-  other: {
-    name: 'その他',
-    badgeClass: 'bg-gray-50 dark:bg-gray-900/20 text-gray-700 dark:text-gray-300',
-    dotClass: 'bg-gray-500 dark:bg-gray-400',
-  },
-}
-
 import { formatEventDateWithExtendedHour } from '@/components/utils/formatEventDateWithExtendedHour'
+
+const PLATFORMS: Record<string, { name: string; dotClass: string }> = {
+  twitch: { name: 'Twitch', dotClass: 'bg-purple-500' },
+  youtube: { name: 'YouTube', dotClass: 'bg-red-500' },
+  nico: { name: 'ニコニコ', dotClass: 'bg-orange-500' },
+  offline: { name: '現地イベント', dotClass: 'bg-emerald-500' },
+  other: { name: 'その他', dotClass: 'bg-slate-400' },
+}
 
 function getEventStatus(startDate: string, endDate?: string | null) {
   const now = new Date()
   const start = new Date(startDate)
   const end = endDate ? new Date(endDate) : null
 
-  if (now < start) {
-    return 'upcoming' // 告知モード
-  } else if (now >= start && (!end || now <= end)) {
-    return 'live' // 開催中モード
-  } else {
-    return 'ended' // 終了（表示しない）
-  }
+  if (now < start) return 'upcoming' // 告知
+  if (now >= start && (!end || now <= end)) return 'live' // 開催中
+  return 'ended'
 }
 
-type EventDoc = Event
 type ActiveEventCardProps = {
-  event: EventDoc
-  cardClass: string
+  event: Event
+  /** 互換のため残置（未使用） */
+  cardClass?: string
 }
 
-export default function ActiveEventCard({ event, cardClass }: ActiveEventCardProps) {
-  const href = event.externalUrl || `/events/${event.slug}`
-  const platform =
-    platformConfig[event.platform as keyof typeof platformConfig] || platformConfig.other
+export default function ActiveEventCard({ event }: ActiveEventCardProps) {
+  const href = event.externalUrl || '/in_event'
+  const platform = PLATFORMS[event.platform ?? 'other'] ?? PLATFORMS.other
   const { date, time } = formatEventDateWithExtendedHour(event.startDate, event.endDate)
   const status = getEventStatus(event.startDate, event.endDate)
 
-  // 終了したイベントは表示しない
-  if (status === 'ended') {
-    return null
-  }
+  if (status === 'ended') return null
 
-  if (status === 'upcoming') {
-    // 告知モード：控えめなカード
-    return (
-      <a
-        href={href}
-        target={event.externalUrl ? '_blank' : undefined}
-        className={`card-link block mb-6 rounded-xl border border-[color:var(--card-border)] bg-[color:var(--card-bg)] backdrop-blur-sm shadow-sm relative overflow-hidden h-24 sm:h-32 hover:shadow-md transition-all duration-300 ${cardClass}`}
-      >
-        <div className="flex h-full">
-          {/* Thumbnail - カード全体サイズに合わせる */}
-          {event.thumbnail &&
-            typeof event.thumbnail === 'object' &&
-            'url' in event.thumbnail &&
-            event.thumbnail.url && (
-              <div className="flex-shrink-0 w-32 sm:w-48 h-full relative">
-                <Image
-                  src={toCFUrl(event.thumbnail.url)}
-                  alt={event.title}
-                  fill
-                  className="object-cover"
-                />
-              </div>
-            )}
+  const isLive = status === 'live'
+  const thumbnailUrl =
+    event.thumbnail &&
+    typeof event.thumbnail === 'object' &&
+    'url' in event.thumbnail &&
+    event.thumbnail.url
+      ? toCFUrl(event.thumbnail.url)
+      : null
 
-          <div className="flex-1 min-w-0 p-2 sm:p-4 flex flex-col justify-center">
-            <div className="flex flex-wrap items-center gap-1 mb-1">
-              <Bell size={10} className="text-blue-500" />
-              <span className="text-xs text-blue-600 font-medium">予定</span>
-              <span
-                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-xl text-xs font-bold shadow-sm transition-colors duration-200 ${platform.badgeClass}`}
-              >
-                <span className={`w-2 h-2 rounded-full mr-1 ${platform.dotClass}`} />
-                {platform.name}
-              </span>
-            </div>
-            <h3 className="text-lg sm:text-base font-semibold text-gray-900 dark:!text-gray-100 line-clamp-2 mb-1">
-              {event.title}
-            </h3>
-            <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500 mb-1">
-              <div className="flex items-center gap-1">
-                <Calendar size={8} />
-                <span>{date}</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <Clock size={8} />
-                <span>{time}</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </a>
-    )
-  }
-
-  // 開催中モード：目立つカード
   return (
     <a
       href={href}
       target={event.externalUrl ? '_blank' : undefined}
-      className={`
-      card-link
-      block mb-6 rounded-xl border-2
-      border-red-400/60 dark:border-red-700/60
-      bg-gradient-to-r from-red-50/90 to-pink-50/90
-      dark:from-red-700/60 dark:via-pink-700/60 dark:to-orange-700/60
-      shadow-xl backdrop-blur-sm relative overflow-hidden
-      h-32 sm:h-40 hover:shadow-2xl transition-all duration-300 ${cardClass}
-    `}
+      rel={event.externalUrl ? 'noopener noreferrer' : undefined}
+      className={`card-link glass-card fade-in-up group block overflow-hidden ${
+        isLive ? 'ring-1 ring-red-400/40' : ''
+      }`}
     >
-      {/* ダークモード背景エフェクト */}
-      <div className="absolute inset-0 opacity-10">
-        <div
-          className="
-        absolute inset-0
-        bg-gradient-to-br from-red-500 via-pink-500 to-orange-500
-        dark:from-red-800 dark:via-pink-800 dark:to-orange-800
-      "
-        />
-      </div>
+      <div className="flex">
+        {/* サムネイル */}
+        {thumbnailUrl && (
+          <div className="relative w-28 shrink-0 sm:w-44">
+            <Image
+              src={thumbnailUrl}
+              alt={event.title}
+              fill
+              sizes="(max-width: 640px) 112px, 176px"
+              className="object-cover"
+            />
+          </div>
+        )}
 
-      <div className="relative h-full">
-        <div className="flex h-full">
-          {/* Thumbnail - unchanged */}
-          {event.thumbnail &&
-            typeof event.thumbnail === 'object' &&
-            'url' in event.thumbnail &&
-            event.thumbnail.url && (
-              <div className="flex-shrink-0 w-32 sm:w-64 h-full relative">
-                <Image
-                  src={toCFUrl(event.thumbnail.url)}
-                  alt={event.title}
-                  fill
-                  className="object-cover"
-                />
-              </div>
-            )}
-
-          {/* Content */}
-          <div className="flex-1 p-2 sm:p-5 flex flex-col justify-center">
-            {/* Header */}
-            <div className="flex flex-wrap items-center gap-1 mb-1">
-              <div
-                className="
-              flex items-center gap-1
-              bg-red-500 dark:bg-red-600 text-white px-2 py-0.5 rounded-full text-xs font-bold
-            "
-              >
-                <div className="w-1 h-1 bg-white rounded-full" />
-                配信中
-              </div>
-              <span
-                className={`inline-flex items-center px-1 py-0.5 rounded-full text-xs font-medium border dark:border-gray-600 ${platform.badgeClass}`}
-              >
-                <div className={`w-1 h-1 rounded-full mr-1 ${platform.dotClass}`} />
-                {platform.name}
+        {/* 本文 */}
+        <div className="min-w-0 flex-1 space-y-1.5 p-4 sm:p-5">
+          <div className="flex flex-wrap items-center gap-1.5">
+            {isLive ? (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-red-500/90 px-2.5 py-0.5 text-[11px] font-semibold text-white">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-white" />
+                開催中
               </span>
-            </div>
+            ) : (
+              <span className="chip">
+                <Bell size={11} className="mr-1" />
+                予定
+              </span>
+            )}
+            <span className="chip">
+              <span className={`mr-1.5 h-1.5 w-1.5 rounded-full ${platform.dotClass}`} />
+              {platform.name}
+            </span>
+          </div>
 
-            {/* Title */}
-            <h2
-              className="
-            text-base sm:text-lg font-bold !text-gray-900 dark:!text-gray-100
-            mb-1 leading-tight line-clamp-2
-          "
-            >
-              {event.title}
-            </h2>
+          <h2 className="line-clamp-2 text-sm font-semibold leading-snug sm:text-base">
+            {event.title}
+          </h2>
 
-            {/* Date and time */}
-            <div
-              className="
-            flex flex-wrap items-center gap-2 text-xs text-gray-600 dark:text-gray-300 mb-2
-          "
-            >
-              <div className="flex items-center gap-0.5">
-                <Calendar size={10} />
-                <span>{date}</span>
-              </div>
-              <div className="flex items-center gap-0.5">
-                <Clock size={10} />
-                <span>{time}</span>
-              </div>
-            </div>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted">
+            <span className="inline-flex items-center gap-1">
+              <Calendar size={12} strokeWidth={1.5} />
+              {date}
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <Clock size={12} strokeWidth={1.5} />
+              {time}
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/cards/ActiveEventCard.tsx
+++ b/src/components/cards/ActiveEventCard.tsx
@@ -1,6 +1,10 @@
 // src/components/cards/ActiveEventCard.tsx
 // トップページのお知らせカード（予定/開催中）。
-// glass-cardベースの横型レイアウトで、開催中は赤リングで控えめに強調する
+// glass-cardベースの横型レイアウトで、開催中は赤リングで控えめに強調する。
+// 開催状態はISRキャッシュの影響を受けないよう、クライアント側で定期再計算する
+'use client'
+
+import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import { Calendar, Clock, Bell } from 'lucide-react'
 import type { Event } from '@/payload-types'
@@ -15,8 +19,7 @@ const PLATFORMS: Record<string, { name: string; dotClass: string }> = {
   other: { name: 'その他', dotClass: 'bg-slate-400' },
 }
 
-function getEventStatus(startDate: string, endDate?: string | null) {
-  const now = new Date()
+function getEventStatus(startDate: string, endDate: string | null | undefined, now: Date) {
   const start = new Date(startDate)
   const end = endDate ? new Date(endDate) : null
 
@@ -35,7 +38,15 @@ export default function ActiveEventCard({ event }: ActiveEventCardProps) {
   const href = event.externalUrl || '/in_event'
   const platform = PLATFORMS[event.platform ?? 'other'] ?? PLATFORMS.other
   const { date, time } = formatEventDateWithExtendedHour(event.startDate, event.endDate)
-  const status = getEventStatus(event.startDate, event.endDate)
+
+  // ISR(60s)で固まった判定を使わず、マウント後は30秒ごとに現在時刻で再計算する
+  const [now, setNow] = useState(() => new Date())
+  useEffect(() => {
+    setNow(new Date())
+    const id = setInterval(() => setNow(new Date()), 30_000)
+    return () => clearInterval(id)
+  }, [])
+  const status = getEventStatus(event.startDate, event.endDate, now)
 
   if (status === 'ended') return null
 

--- a/src/components/cards/EventCard.tsx
+++ b/src/components/cards/EventCard.tsx
@@ -1,145 +1,95 @@
-// src/components/EventCard.tsx
+// src/components/cards/EventCard.tsx
+// イベント一覧用カード。glass-cardデザインシステムに統一し、
+// プラットフォームは色付きドット+チップで控えめに示す
 import Image from 'next/image'
 import Link from 'next/link'
 import { ExternalLink, Calendar, Clock } from 'lucide-react'
 import type { Event } from '@/payload-types'
 import { toCFUrl } from '@/lib/cfUrl'
-
-const platformConfig = {
-  twitch: {
-    name: 'Twitch',
-    badgeClass: 'bg-purple-50 dark:bg-purple-900/20 text-purple-700 dark:text-purple-200',
-    dotClass: 'bg-purple-500 dark:bg-purple-400',
-  },
-  youtube: {
-    name: 'YouTube',
-    badgeClass: 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-200',
-    dotClass: 'bg-red-500 dark:bg-red-400',
-  },
-  nico: {
-    name: 'ニコニコ',
-    badgeClass: 'bg-orange-50 dark:bg-orange-900/20 text-orange-700 dark:text-orange-200',
-    dotClass: 'bg-orange-500 dark:bg-orange-400',
-  },
-  offline: {
-    name: '現地イベント',
-    badgeClass: 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-200',
-    dotClass: 'bg-green-500 dark:bg-green-400',
-  },
-  other: {
-    name: 'その他',
-    badgeClass: 'bg-gray-50 dark:bg-gray-900/20 text-gray-700 dark:text-gray-200',
-    dotClass: 'bg-gray-500 dark:bg-gray-400',
-  },
-}
-
 import { formatEventDateWithExtendedHour } from '@/components/utils/formatEventDateWithExtendedHour'
 
+const PLATFORMS: Record<string, { name: string; dotClass: string }> = {
+  twitch: { name: 'Twitch', dotClass: 'bg-purple-500' },
+  youtube: { name: 'YouTube', dotClass: 'bg-red-500' },
+  nico: { name: 'ニコニコ', dotClass: 'bg-orange-500' },
+  offline: { name: '現地イベント', dotClass: 'bg-emerald-500' },
+  other: { name: 'その他', dotClass: 'bg-slate-400' },
+}
 
 export default function EventCard({ e }: { e: Event }) {
-  const platform = platformConfig[e.platform as keyof typeof platformConfig] || platformConfig.other
+  const platform = PLATFORMS[e.platform ?? 'other'] ?? PLATFORMS.other
   const { date, time } = formatEventDateWithExtendedHour(e.startDate, e.endDate)
-  const isLive = e.externalUrl && new Date(e.startDate) <= new Date() && (!e.endDate || new Date(e.endDate) >= new Date())
+  const isLive =
+    new Date(e.startDate) <= new Date() && (!e.endDate || new Date(e.endDate) >= new Date())
+  const thumbnailUrl =
+    e.thumbnail && typeof e.thumbnail === 'object' && 'url' in e.thumbnail && e.thumbnail.url
+      ? toCFUrl(e.thumbnail.url)
+      : null
 
   return (
     <Link
-      href={e.externalUrl || `/events/${e.slug}`}
+      href={e.externalUrl || `/in_event`}
       target={e.externalUrl ? '_blank' : undefined}
-      className="block no-underline"
+      rel={e.externalUrl ? 'noopener noreferrer' : undefined}
+      className="card-link group block"
     >
-      <article
-        className={`
-          group relative
-          bg-[color:var(--card-bg)] hover:bg-[color:var(--card-bg-hover)]
-          backdrop-blur-xl
-          border border-[color:var(--card-border)] hover:border-[color:var(--card-border-hover)]
-          shadow-lg hover:shadow-xl
-          transition-all duration-500
-          rounded-2xl overflow-hidden
-          text-gray-900 dark:text-white
-        `}
-      >
-        {/* Live indicator */}
-        {isLive && (
-          <div className="absolute top-4 right-4 z-10 flex items-center gap-1.5 bg-red-500/90 backdrop-blur-sm text-white px-3 py-1.5 rounded-full text-xs font-semibold shadow-lg">
-            <div className="w-2 h-2 bg-white rounded-full animate-pulse" />
-            LIVE
-          </div>
-        )}
-        
-        {/* Thumbnail */}
-        <div className="relative h-52 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-700 overflow-hidden">
-          {e.thumbnail && typeof e.thumbnail === 'object' && 'url' in e.thumbnail && e.thumbnail.url ? (
+      <article className="glass-card fade-in-up overflow-hidden">
+        {/* サムネイル */}
+        <div className="relative aspect-[16/9] overflow-hidden">
+          {thumbnailUrl ? (
             <Image
-              src={toCFUrl(e.thumbnail.url)}
+              src={thumbnailUrl}
               alt={e.title}
               fill
-              className="object-cover group-hover:scale-110 transition-transform duration-700 ease-out"
+              sizes="(max-width: 640px) 100vw, 480px"
+              className="object-cover transition-transform duration-500 ease-out group-hover:scale-[1.03]"
             />
           ) : (
-            <div className="absolute inset-0 flex items-center justify-center text-gray-300">
-              <Calendar size={56} strokeWidth={1.5} />
+            <div className="absolute inset-0 flex items-center justify-center bg-[color:var(--chip-bg)] text-muted">
+              <Calendar size={40} strokeWidth={1.5} />
             </div>
           )}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
-          
-          {/* Glassmorphism overlay */}
-          <div className="absolute inset-0 bg-gradient-to-t from-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+
+          {/* LIVEバッジ */}
+          {isLive && (
+            <span className="absolute right-3 top-3 z-10 inline-flex items-center gap-1.5 rounded-full bg-red-500/90 px-2.5 py-1 text-[11px] font-semibold text-white backdrop-blur-sm">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-white" />
+              LIVE
+            </span>
+          )}
         </div>
-        
-        {/* Content */}
-        <div className="p-6 space-y-4">
-          {/* Platform badge */}
-          <div className="flex items-center justify-between">
-            <span
-  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-xl text-xs font-bold shadow-sm transition-colors duration-200 ${platform.badgeClass}`}
->
-  <span className={`w-2 h-2 rounded-full mr-1 ${platform.dotClass}`} />
-  {platform.name}
-</span>
+
+        {/* 本文 */}
+        <div className="space-y-2.5 p-5">
+          <div className="flex items-center justify-between gap-2">
+            <span className="chip">
+              <span className={`mr-1.5 h-1.5 w-1.5 rounded-full ${platform.dotClass}`} />
+              {platform.name}
+            </span>
             {e.externalUrl && (
-              <ExternalLink size={16} className="!text-gray-400 dark:!text-gray-400 group-hover:!text-blue-500 transition-colors duration-300" strokeWidth={1.5} />
+              <ExternalLink
+                size={14}
+                strokeWidth={1.5}
+                className="shrink-0 text-muted transition-opacity group-hover:opacity-70"
+              />
             )}
           </div>
-          
-          {/* Title */}
-          <h3
-            className="
-              font-bold text-xl leading-tight
-              text-[color:var(--fg-base)]
-              group-hover:text-blue-600 dark:group-hover:text-blue-400
-              transition-colors duration-300
-              line-clamp-2
-            "
-          >
-            {e.title}
-          </h3>
 
-          {/* Summary */}
+          <h2 className="line-clamp-2 text-base font-semibold leading-snug">{e.title}</h2>
+
           {e.summary && (
-            <p className="text-sm leading-relaxed line-clamp-2 opacity-80 text-[color:var(--fg-base)]">
-              {e.summary}
-            </p>
+            <p className="line-clamp-2 text-sm leading-relaxed text-muted">{e.summary}</p>
           )}
 
-          {/* Date and time */}
-          <div
-            className="
-              flex items-center gap-6 text-sm
-              pt-2
-              border-t border-gray-300/50 dark:border-gray-600/40
-              opacity-70
-              text-[color:var(--fg-base)]
-            "
-          >
-            <div className="flex items-center gap-2">
-              <Calendar size={14} strokeWidth={1.5} />
-              <span className="font-medium">{date}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Clock size={14} strokeWidth={1.5} />
-              <span className="font-medium">{time}</span>
-            </div>
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-t border-[color:var(--glass-border)] pt-2.5 text-xs text-muted">
+            <span className="inline-flex items-center gap-1.5">
+              <Calendar size={13} strokeWidth={1.5} />
+              {date}
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <Clock size={13} strokeWidth={1.5} />
+              {time}
+            </span>
           </div>
         </div>
       </article>

--- a/src/components/timeline/TimelineCard.tsx
+++ b/src/components/timeline/TimelineCard.tsx
@@ -121,23 +121,23 @@ export default function TimelineCard({
         />
       )}
 
-      {/* 画像（最大3枚） */}
+      {/* 画像（最大3枚）。固定幅ではなくグリッドでSPでもはみ出さない */}
       {post.images?.length ? (
-        <div className="mt-3 flex gap-2">
+        <div className="mt-3 grid max-w-md grid-cols-3 gap-2">
           {post.images.slice(0, 3).map((imgObj) =>
             imgObj?.image?.url ? (
               <button
                 key={imgObj.id || imgObj.image?.id}
                 type="button"
                 aria-label="画像を拡大表示"
-                className="relative h-28 w-28 cursor-zoom-in overflow-hidden rounded-xl sm:h-32 sm:w-32"
+                className="relative aspect-square cursor-zoom-in overflow-hidden rounded-xl"
                 onClick={() => onImageClick?.(imgObj.image.url)}
               >
                 <Image
                   src={toCFUrl(imgObj.image.sizes?.thumbnail?.url ?? imgObj.image.url)}
                   alt={post.title ?? 'timeline-img'}
                   fill
-                  sizes="(max-width: 640px) 33vw, 128px"
+                  sizes="(max-width: 640px) 33vw, 150px"
                   quality={75}
                   className="object-cover transition-transform duration-300 hover:scale-[1.03]"
                   loading="lazy"


### PR DESCRIPTION
## Summary

1. **タブ切替時の横ずれ解消**: ページごとにバラバラだったコンテナ幅（58rem/78rem/28rem/64rem…）をレイアウト層の単一`max-w-5xl`コンテナに統一。`scrollbar-gutter: stable`でスクロールバー有無によるずれも防止
2. **SP表示崩れ修正**: タイムラインカードの固定幅画像（3×128px=はみ出し）をレスポンシブグリッド化、見出し行の折返し対応
3. **イベントカードの抜本刷新**: 派手なグラデーションを廃止し、透明感のあるglass-cardデザインシステムに統一

## Changes

### 📐 レイアウト統一
- `(frontend)/layout.tsx`が全ページ共通の`max-w-5xl px-4 sm:px-6`コンテナを提供
- 8ページ分の独自`max-w`/`px`指定を撤去（内側の narrower コンテンツ幅は維持：タイムライン=2xl、プロフィール/レター=28rem）
- `html { scrollbar-gutter: stable }`

### 📱 SP修正
- `TimelineCard`: 画像を`grid grid-cols-3` + `aspect-square`に（375px幅でのオーバーフロー解消）
- Timeline見出し行を`flex-wrap`化
- 全ページ見出しを`text-2xl tracking-wide`に統一

### 🎫 イベントカード
- `EventCard`: glass-card化。16:9サムネイル、`chip`+色ドットのプラットフォーム表示、LIVEバッジ、境界線付き日時フッター
- `ActiveEventCard`: 横型glass-cardに一新。開催中は`ring-red-400/40`+バッジで控えめに強調

## Test Plan
- [x] `pnpm build` 成功
- [x] 全8ページ200・統一コンテナ描画確認
- [x] タイムラインの固定幅画像が0件になったことを確認
- [x] /in_event でEventCardのglass-card描画確認
- [ ] Vercelプレビューで実機SP確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * イベントカードやタイムラインの表示デザインを刷新し、見た目と配置の一貫性を向上しました。
* **Bug Fixes**
  * スクロールバー表示による横ずれを抑え、ページ遷移時のレイアウトの安定性を改善しました。
  * 各ページの余白・中央寄せの調整により、表示崩れを起こしにくくしました。
* **Chores**
  * サイトマップの更新日時を最新化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->