### PR TITLE
fix: パンくずをレイアウト層で一元描画し全ページ同一位置に

### DIFF
--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://iwabuchi-makoto.com/letter</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/timeline</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/posts</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/gallery</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/products</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/profile</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/in_event</loc><lastmod>2026-07-03T17:18:53.459Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/letter</loc><lastmod>2026-07-03T17:28:36.976Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com</loc><lastmod>2026-07-03T17:28:36.976Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/timeline</loc><lastmod>2026-07-03T17:28:36.977Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/posts</loc><lastmod>2026-07-03T17:28:36.977Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/gallery</loc><lastmod>2026-07-03T17:28:36.977Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/products</loc><lastmod>2026-07-03T17:28:36.977Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/profile</loc><lastmod>2026-07-03T17:28:36.977Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/in_event</loc><lastmod>2026-07-03T17:28:36.977Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/(frontend)/gallery/page.tsx
+++ b/src/app/(frontend)/gallery/page.tsx
@@ -3,7 +3,6 @@
 // ───────────────────────────────────────────
 
 import type { Metadata } from 'next'
-import Breadcrumb from '@/components/layout/Breadcrumb'
 import { fetchLatest } from '@/lib/payload'
 import GalleryGrid from '@/components/gallery/GalleryGridMain'
 
@@ -53,10 +52,6 @@ export default async function GalleryPage() {
   return (
     <main className="min-h-screen flex flex-col">
       {/* パンくず */}
-      <div className="pt-6">
-        <Breadcrumb />
-      </div>
-
       {/* セクションラップ */}
       <section className="section-pad">
         <div className="mb-6">

--- a/src/app/(frontend)/in_event/page.tsx
+++ b/src/app/(frontend)/in_event/page.tsx
@@ -1,6 +1,5 @@
 import { fetchInEvent } from '@/lib/fetchInEvent'
 import EventCard from '@/components/cards/EventCard'
-import Breadcrumb from '@/components/layout/Breadcrumb'
 
 export const metadata = { title: 'イベント一覧 | 岩渕誠（いわぶちまこと）' }
 export const dynamic = 'force-dynamic'
@@ -12,11 +11,7 @@ export default async function InEventPage() {
   const inEvent = await fetchInEvent()
 
   return (
-    <main className="min-h-screen flex flex-col bg-[color:var(--bg-base)]">
-      <div className="pt-6">
-        <Breadcrumb />
-      </div>
-      <section className={WRAP}>
+    <main className="min-h-screen flex flex-col bg-[color:var(--bg-base)]">      <section className={WRAP}>
         <h1 className="text-2xl font-semibold tracking-wide mb-8">Events</h1>
         {inEvent.length === 0 && <p className="text-[color:var(--fg-base)]">現在予定されているイベントはありません。</p>}
         <div className="grid gap-6 sm:grid-cols-2">

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next'
 import React from 'react'
 import GlassNav from '@/components/layout/GlassNav'
 import SiteFooter from '@/components/layout/SiteFooter'
+import Breadcrumb from '@/components/layout/Breadcrumb'
 import { toCFUrl } from '@/lib/cfUrl'
 import { Providers } from '@/components/Providers'
 
@@ -167,7 +168,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
           {/* ── 1カラムのメインコンテンツ（各ページが <main> を持つため div）
                全ページ同一のコンテナ幅にすることで、ページ遷移時の横ずれを防ぐ ── */}
-          <div className="mx-auto min-h-screen w-full max-w-5xl px-4 sm:px-6">{children}</div>
+          <div className="mx-auto min-h-screen w-full max-w-5xl px-4 sm:px-6">
+            {/* パンくずはレイアウト層で一元描画（ページごとの位置ずれを防ぐ） */}
+            <Breadcrumb />
+            {children}
+          </div>
 
           {/* ── フッター ── */}
           <SiteFooter />

--- a/src/app/(frontend)/letter/page.tsx
+++ b/src/app/(frontend)/letter/page.tsx
@@ -2,7 +2,6 @@
 'use client'
 
 import { useState } from 'react'
-import Breadcrumb from '@/components/layout/Breadcrumb'
 
 const WRAP = 'mx-auto w-full max-w-[28rem] section-pad flex justify-center'
 const CARD = 'glass p-8 flex flex-col gap-4 w-full'
@@ -40,11 +39,7 @@ export default function LetterPage() {
   }
 
   return (
-    <main className="min-h-screen flex flex-col">
-      <div className="pt-6">
-        <Breadcrumb />
-        </div>
-      <section className={WRAP}>
+    <main className="min-h-screen flex flex-col">      <section className={WRAP}>
         <form onSubmit={handleSubmit} className={CARD}>
           <h1 className="text-2xl font-semibold mb-4">お便りを送る</h1>
           <input

--- a/src/app/(frontend)/posts/[slug]/page.tsx
+++ b/src/app/(frontend)/posts/[slug]/page.tsx
@@ -10,7 +10,6 @@ import { getPayloadClient } from '@/lib/payloadClient'
 import { toCFUrl } from '@/lib/cfUrl'
 import type { BlogPost } from '@/lib/payloadTypes'
 import { RenderRichTextWithModal } from '@/lib/renderRichTextWithModal'
-import Breadcrumb from '@/components/layout/Breadcrumb'
 
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
   const { slug } = await params
@@ -119,11 +118,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <main className="min-h-screen flex flex-col">
-      <div className="pt-6">
-        <Breadcrumb />
-      </div>
-      <section className={WRAP}>
+      <main className="min-h-screen flex flex-col">      <section className={WRAP}>
           {post.coverImage?.url && (
             <div className="relative w-full h-64 mb-6">
               <Image

--- a/src/app/(frontend)/posts/page.tsx
+++ b/src/app/(frontend)/posts/page.tsx
@@ -5,7 +5,6 @@ export const revalidate = 0
 
 import type { Metadata } from 'next'
 import { fetchLatest } from '@/lib/payload'
-import Breadcrumb from '@/components/layout/Breadcrumb'
 import { Suspense } from 'react'
 import PostsList from './PostsList'
 import PostsListLoading from './PostsListLoading'
@@ -49,11 +48,7 @@ export default async function BlogPage() {
   const { posts } = await fetchLatest({ blogLimit: 10 })
 
   return (
-    <main className="min-h-screen flex flex-col">
-      <div className="pt-6">
-        <Breadcrumb />
-      </div>
-      <section className={WRAP}>
+    <main className="min-h-screen flex flex-col">      <section className={WRAP}>
         <h1 className="text-2xl font-semibold tracking-wide mb-2">Blog</h1>
         <p className="mb-8 opacity-80">考えていることを書き留めておく場所</p>
         {/* Suspense でラップ！ */}

--- a/src/app/(frontend)/products/page.tsx
+++ b/src/app/(frontend)/products/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import { fetchProducts } from '@/lib/fetchProducts'
 import ProductCard from '@/components/cards/ProductCard'
-import Breadcrumb from '@/components/layout/Breadcrumb'
 
 export const metadata: Metadata = {
   title: 'プロダクト | 岩渕誠（いわぶちまこと）',
@@ -43,11 +42,7 @@ export default async function ProductsPage() {
   const products = await fetchProducts()
 
   return (
-    <main className="min-h-screen flex flex-col">
-      <div className="pt-6">
-        <Breadcrumb />
-      </div>
-      <section className={WRAP}>
+    <main className="min-h-screen flex flex-col">      <section className={WRAP}>
         <h1 className="text-2xl font-semibold tracking-wide mb-8">Products</h1>
         {products.length === 0 && <p>まだ公開されていません。</p>}
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/app/(frontend)/profile/page.tsx
+++ b/src/app/(frontend)/profile/page.tsx
@@ -7,7 +7,6 @@ export const revalidate = 0
 import Image from 'next/image'
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import Breadcrumb from '@/components/layout/Breadcrumb'
 import { toCFUrl } from '@/lib/cfUrl'
 import { getPayloadClient } from '@/lib/payloadClient'
 
@@ -127,11 +126,7 @@ export default async function ProfilePage() {
   return (
     <>
       <link rel="preload" as="image" href={profileImageUrl} />
-      <main className="min-h-screen flex flex-col">
-        <div className="pt-6">
-          <Breadcrumb />
-        </div>
-        <section className={WRAP}>
+      <main className="min-h-screen flex flex-col">        <section className={WRAP}>
           <div className={CARD}>
             <div className="relative w-40 h-40 rounded-full mb-6 overflow-hidden">
               <Image

--- a/src/app/(frontend)/timeline/page.tsx
+++ b/src/app/(frontend)/timeline/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import Breadcrumb from '@/components/layout/Breadcrumb'
 import WeatherWidgetClient from '@/components/widgets/WeatherWidgetClient'
 import TimelineList from '@/components/timeline/TimelineList'
 import AdminLinks from '@/components/admin/AdminLinks'
@@ -49,10 +48,6 @@ export default async function TimelinePage() {
 
   return (
     <main className="mx-auto w-full max-w-2xl pb-20">
-      <div className="pt-6">
-        <Breadcrumb />
-      </div>
-
       <section className="pt-6">
         <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-baseline gap-3">

--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -17,6 +17,9 @@ export default function Breadcrumb({
   const pathname = usePathname()
   const segments = pathname?.split('/').filter(Boolean) || []
 
+  // トップページでは表示しない（レイアウト層から全ページ共通で描画されるため）
+  if (segments.length === 0) return null
+
   // 「/foo/bar/baz」で [ {href:'/',label:'Home'}, {href:'/foo',label:'foo'}, ... ]
   const autoItems: Crumb[] = [
     { href: '/', label: 'Home' },
@@ -43,8 +46,8 @@ export default function Breadcrumb({
   }
 
   return (
-    // コンテナはページ側に任せる（独自の max-w/px を持つと本文と整列しないため）
-    <nav aria-label="Breadcrumb" className="text-[13px] text-muted">
+    // レイアウト層の統一コンテナ直下に置かれるため、全ページで同一位置に表示される
+    <nav aria-label="Breadcrumb" className="pt-6 text-[13px] text-muted">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}


### PR DESCRIPTION
## Summary

タブ切替時にパンくずの位置がずれる問題の恒久対策。タイムラインだけパンくずが `max-w-2xl`（中央寄せ狭幅）コンテナの内側に置かれており、他ページ（`max-w-5xl` 左端）と開始位置が異なっていた。

## Changes

- パンくずを `(frontend)/layout.tsx` の統一コンテナ直下で**一元描画**する構造に変更
- 8ページ分の個別 `<Breadcrumb />` 配置と import を撤去（今後ページを追加してもずれない）
- トップページ（`/`）ではパンくず自身が非表示判定
- BreadcrumbList構造化データは維持

## Test Plan
- [x] `pnpm build` 成功
- [x] 全8ページ検証: `/`=0個・他7ページ=各1個、すべてレイアウト層の同一位置に描画
- [ ] Vercelプレビューでタブ切替時の位置固定を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)