### PR TITLE
fix: 本番で天気・気温が取得できない問題を修正（サーバープロキシ+met.noフォールバック）

### DIFF
--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://iwabuchi-makoto.com/letter</loc><lastmod>2026-07-04T02:48:22.576Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com</loc><lastmod>2026-07-04T02:48:22.577Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/timeline</loc><lastmod>2026-07-04T02:48:22.577Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/posts</loc><lastmod>2026-07-04T02:48:22.577Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/gallery</loc><lastmod>2026-07-04T02:48:22.577Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/products</loc><lastmod>2026-07-04T02:48:22.577Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/profile</loc><lastmod>2026-07-04T02:48:22.577Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://iwabuchi-makoto.com/in_event</loc><lastmod>2026-07-04T02:48:22.577Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/letter</loc><lastmod>2026-07-04T03:09:27.819Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com</loc><lastmod>2026-07-04T03:09:27.820Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/timeline</loc><lastmod>2026-07-04T03:09:27.820Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/posts</loc><lastmod>2026-07-04T03:09:27.820Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/gallery</loc><lastmod>2026-07-04T03:09:27.820Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/products</loc><lastmod>2026-07-04T03:09:27.820Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/profile</loc><lastmod>2026-07-04T03:09:27.820Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://iwabuchi-makoto.com/in_event</loc><lastmod>2026-07-04T03:09:27.820Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -1,0 +1,122 @@
+// src/app/api/weather/route.ts
+// 天気プロキシAPI。
+// ブラウザから open-meteo を直接叩くと利用者の回線によって到達できない
+// ことがある（日本の一部ISPからタイムアウトする事例あり）ため、
+// サーバー側で取得し、失敗時は met.no にフォールバックする。
+import { NextRequest, NextResponse } from 'next/server'
+
+export const revalidate = 0 // キャッシュはレスポンスヘッダーで制御
+
+const FETCH_TIMEOUT_MS = 5000
+// 東京（位置情報が取れない場合のデフォルト）
+const DEFAULT_LAT = 35.6762
+const DEFAULT_LON = 139.6503
+
+/** met.no の symbol_code を WMO weather code（open-meteo互換）へ近似変換 */
+const METNO_SYMBOL_TO_WMO: Record<string, number> = {
+  clearsky: 0,
+  fair: 1,
+  partlycloudy: 2,
+  cloudy: 3,
+  fog: 45,
+  lightrainshowers: 51,
+  rainshowers: 80,
+  heavyrainshowers: 82,
+  lightrain: 61,
+  rain: 63,
+  heavyrain: 65,
+  lightsleet: 66,
+  sleet: 66,
+  heavysleet: 67,
+  lightsleetshowers: 66,
+  sleetshowers: 66,
+  heavysleetshowers: 67,
+  lightsnow: 71,
+  snow: 73,
+  heavysnow: 75,
+  lightsnowshowers: 85,
+  snowshowers: 85,
+  heavysnowshowers: 86,
+  lightrainandthunder: 95,
+  rainandthunder: 95,
+  heavyrainandthunder: 95,
+  thunder: 95,
+}
+
+async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Response> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** open-meteo から取得（プライマリ） */
+async function fetchOpenMeteo(lat: number, lon: number) {
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat.toFixed(4)}&longitude=${lon.toFixed(4)}&current=temperature_2m,weather_code&timezone=auto`
+  const res = await fetchWithTimeout(url)
+  if (!res.ok) throw new Error(`open-meteo: ${res.status}`)
+  const data = await res.json()
+  return {
+    temp: Math.round(data.current.temperature_2m),
+    code: Number(data.current.weather_code),
+    source: 'open-meteo',
+  }
+}
+
+/** met.no から取得（フォールバック） */
+async function fetchMetNo(lat: number, lon: number) {
+  const url = `https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=${lat.toFixed(4)}&lon=${lon.toFixed(4)}`
+  const res = await fetchWithTimeout(url, {
+    headers: {
+      // met.no の利用規約でUser-Agentによる識別が必須
+      'User-Agent': 'iwabuchi-makoto.com weather-widget (https://iwabuchi-makoto.com)',
+    },
+  })
+  if (!res.ok) throw new Error(`met.no: ${res.status}`)
+  const data = await res.json()
+  const ts = data?.properties?.timeseries?.[0]
+  const temp = ts?.data?.instant?.details?.air_temperature
+  const symbol: string =
+    ts?.data?.next_1_hours?.summary?.symbol_code ??
+    ts?.data?.next_6_hours?.summary?.symbol_code ??
+    ''
+  // 'lightrain_day' のような接尾辞を除去してWMOコードへ変換
+  const base = symbol.split('_')[0]
+  return {
+    temp: Math.round(Number(temp)),
+    code: METNO_SYMBOL_TO_WMO[base] ?? 3,
+    source: 'met.no',
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const latRaw = parseFloat(searchParams.get('lat') ?? '')
+  const lonRaw = parseFloat(searchParams.get('lon') ?? '')
+  // 不正値はデフォルト（東京）に丸める
+  const lat = Number.isFinite(latRaw) && Math.abs(latRaw) <= 90 ? latRaw : DEFAULT_LAT
+  const lon = Number.isFinite(lonRaw) && Math.abs(lonRaw) <= 180 ? lonRaw : DEFAULT_LON
+
+  try {
+    let result
+    try {
+      result = await fetchOpenMeteo(lat, lon)
+    } catch (error) {
+      console.warn('Weather: open-meteo failed, falling back to met.no:', error)
+      result = await fetchMetNo(lat, lon)
+    }
+
+    return NextResponse.json(result, {
+      headers: {
+        // 10分CDNキャッシュ + 30分stale許容（外部APIへの負荷と応答速度の両立）
+        'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=1800',
+      },
+    })
+  } catch (error) {
+    console.error('Weather: all providers failed:', error)
+    return NextResponse.json({ error: 'Weather unavailable' }, { status: 502 })
+  }
+}

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -29,66 +29,46 @@ export default function WeatherWidget({ className = '' }: { className?: string }
     return () => clearInterval(intervalId)
   }, [now])
 
-  /* IP位置情報 → Open-Meteo (ポップアップなし) */
+  /* IP位置情報 → 自サイトの /api/weather プロキシ経由で取得
+     （open-meteoへ直接アクセスすると利用者の回線によって到達できない
+     ことがあるため、サーバー側で取得・フォールバックする） */
   useEffect(() => {
+    const fetchWeather = async (lat?: string, lon?: string, locationName = 'Tokyo') => {
+      const query = lat && lon ? `?lat=${parseFloat(lat)}&lon=${parseFloat(lon)}` : ''
+      const res = await fetch(`/api/weather${query}`)
+      if (!res.ok) throw new Error(`Weather API failed: ${res.status}`)
+      const data = await res.json()
+      setWx({
+        temp: `${data.temp}°C`,
+        icon: codeToIcon(data.code),
+        location: locationName,
+      })
+    }
+
     const getWeatherByIP = async () => {
       try {
-        // ipinfo.io を使用（より安定したサービス）
-        const locationResponse = await fetch('https://ipinfo.io/json?token=')
+        // ipinfo.io でおおよその位置を取得（ポップアップなし）
+        const locationResponse = await fetch('https://ipinfo.io/json')
         if (!locationResponse.ok) throw new Error('IP location failed')
-        
+
         const locationData = await locationResponse.json()
-        
-        if (locationData.loc) {
-          const [lat, lon] = locationData.loc.split(',')
-          const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=${parseFloat(lat).toFixed(
-            4,
-          )}&longitude=${parseFloat(lon).toFixed(
-            4,
-          )}&current=temperature_2m,weather_code&timezone=auto`
-          
-          const weatherResponse = await fetch(weatherUrl)
-          if (!weatherResponse.ok) throw new Error('Weather API failed')
-          
-          const weatherData = await weatherResponse.json()
-          
-          // 都市名を取得（英語）
-          const locationName = locationData.city || locationData.region || 'Unknown'
-          
-          setWx({
-            temp: Math.round(weatherData.current.temperature_2m) + '°C',
-            icon: codeToIcon(weatherData.current.weather_code),
-            location: locationName,
-          })
-        } else {
-          throw new Error('No location data')
-        }
+        if (!locationData.loc) throw new Error('No location data')
+
+        const [lat, lon] = locationData.loc.split(',')
+        const locationName = locationData.city || locationData.region || 'Unknown'
+        await fetchWeather(lat, lon, locationName)
       } catch (error) {
         console.warn('IP-based weather failed, using fallback:', error)
-        await getFallbackWeather()
-      }
-    }
-    
-    const getFallbackWeather = async () => {
-      try {
-        // 東京の座標 (35.6762, 139.6503) - 日本のユーザー向けのデフォルト
-        const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=35.6762&longitude=139.6503&current=temperature_2m,weather_code&timezone=Asia/Tokyo`
-        const weatherResponse = await fetch(weatherUrl)
-        
-        if (weatherResponse.ok) {
-          const weatherData = await weatherResponse.json()
-          setWx({
-            temp: Math.round(weatherData.current.temperature_2m) + '°C',
-            icon: codeToIcon(weatherData.current.weather_code),
-            location: 'Tokyo',
-          })
+        try {
+          // 位置情報なし＝東京の天気にフォールバック
+          await fetchWeather()
+        } catch (fallbackError) {
+          console.warn('Fallback weather also failed:', fallbackError)
+          // 完全にフェイルした場合は時刻のみ表示
         }
-      } catch (error) {
-        console.warn('Fallback weather also failed:', error)
-        // 完全にフェイルした場合は時刻のみ表示
       }
     }
-    
+
     getWeatherByIP()
   }, [])
 

--- a/src/components/widgets/WeatherWidget.tsx
+++ b/src/components/widgets/WeatherWidget.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 
-type Wx = { temp: string; icon: string; location: string } | null
+type Wx = { temp: string; icon: string; location: string; source?: string } | null
 
 export default function WeatherWidget({ className = '' }: { className?: string }) {
   const [wx, setWx] = useState<Wx>(null)
@@ -42,6 +42,7 @@ export default function WeatherWidget({ className = '' }: { className?: string }
         temp: `${data.temp}°C`,
         icon: codeToIcon(data.code),
         location: locationName,
+        source: data.source,
       })
     }
 
@@ -82,6 +83,18 @@ export default function WeatherWidget({ className = '' }: { className?: string }
           <span>{wx.icon}</span>
           <span>{wx.temp}</span>
           <span className="text-gray-500 dark:text-gray-400">in {wx.location}</span>
+          {/* met.no のデータ利用時はライセンス(NLOD/CC BY 4.0)に基づく帰属表示が必要 */}
+          {wx.source === 'met.no' && (
+            <a
+              href="https://www.met.no/en"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[10px] text-gray-400 underline decoration-dotted underline-offset-2 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+              title="Weather data by MET Norway (NLOD / CC BY 4.0)"
+            >
+              MET Norway
+            </a>
+          )}
         </>
       ) : (
         <>


### PR DESCRIPTION
## Summary

本番で天気ウィジェットの気温が取得できなくなっていた問題の修正。

**原因**: ブラウザから `api.open-meteo.com` を直接fetchしていたが、**日本の一部ISP（NURO等）からこのホストに到達できない**（20秒タイムアウト×3回確認）。グローバル障害ではなく経路の問題（[類似報告](https://github.com/open-meteo/open-meteo/issues/1669)）のため、利用者の回線次第で壊れる設計だった。

## Changes

- **`/api/weather` プロキシ新設**: サーバー側（Vercel）で取得するため利用者の回線に依存しない
  - プライマリ: open-meteo（5秒タイムアウト）
  - フォールバック: **met.no**（ノルウェー気象研究所、無料・キー不要、日本から1.4秒で応答確認済み）
  - met.no の symbol_code → WMO コード近似変換で既存の絵文字アイコン表示を維持
  - 座標バリデーション（不正値は東京にフォールバック）
  - CDNキャッシュ `s-maxage=600, stale-while-revalidate=1800` で外部APIへの負荷も削減
- `WeatherWidget`: プロキシ経由に変更（ipinfo.io での位置推定は継続 — こちらは正常動作を確認済み）

## Test Plan
- [x] `pnpm build` 成功
- [x] **実地フォールバックテスト**: open-meteo到達不能な回線上で `/api/weather` → met.noから `{"temp":25,"code":61,"source":"met.no"}` を取得（直接APIの値と一致）
- [x] 座標指定・不正値（lat=abc/lon=999→東京化）の動作確認
- [ ] Vercel本番で気温表示の復活を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)