### PR TITLE
feat: 写真をX/Threads方式に刷新・レイアウト幅再配分・タイトルをタイプ演出で統一

### DIFF
--- a/src/app/(frontend)/mist.css
+++ b/src/app/(frontend)/mist.css
@@ -279,14 +279,15 @@
 /* ── main grid（右レール 320px 固定・左可変） ─────────── */
 .mist .main {
   display: grid;
-  grid-template-columns: 1fr 320px;
-  gap: 36px;
+  grid-template-columns: minmax(0, 1fr) 380px;
+  gap: 40px;
+  max-width: 1160px; /* フィード肥大化を防ぐ。左寄せ（hero と左端を揃える） */
   padding: 32px var(--m-pad) 0;
   align-items: start;
 }
 /* 1080px 未満は1カラムに畳む */
 @media (max-width: 1080px) {
-  .mist .main { grid-template-columns: 1fr; }
+  .mist .main { grid-template-columns: 1fr; max-width: none; }
 }
 
 /* git log 風タイムライン */
@@ -392,22 +393,44 @@
   background: oklch(0.92 0.03 268 / 0.6);
 }
 .mist .commit .likes:disabled { cursor: default; }
-/* 写真: 横幅いっぱいで極端な横長にならないよう最大幅と高さで比率を抑える */
-.mist .photos { display: flex; gap: 10px; max-width: 600px; }
+/* 写真: 枚数別レイアウト（X/Threads 方式）。縦横比は Media の width/height から算出。
+   1枚は縦画像をトリミングせず高さ基準で表示、複数枚はグリッドで object-cover。 */
+.mist .photos { max-width: 640px; }
 .mist .photos .ph {
   position: relative;
-  height: 230px;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.95);
   outline: 1px solid var(--m-hairline);
   padding: 0;
+  margin: 0;
   cursor: zoom-in;
   transition: filter 0.25s;
 }
 .mist .photos .ph:hover { filter: brightness(0.94); }
+/* 1枚: インラインstyle（width/aspect-ratio/max-height）でサイズを決める */
+.mist .photos.one { font-size: 0; }
+.mist .photos.one .ph { display: block; }
+/* 複数枚: グリッド。各セルは object-cover でセルを埋める */
+.mist .photos.two,
+.mist .photos.three,
+.mist .photos.four {
+  display: grid;
+  gap: 4px;
+}
+.mist .photos.two { grid-template-columns: 1fr 1fr; aspect-ratio: 16 / 9; }
+.mist .photos.three {
+  grid-template-columns: 2fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  aspect-ratio: 16 / 10;
+}
+.mist .photos.three .ph:first-child { grid-row: 1 / 3; }
+.mist .photos.four {
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  aspect-ratio: 4 / 3;
+}
 @media (max-width: 640px) {
-  .mist .photos { max-width: none; }
-  .mist .photos .ph { height: 150px; }
+  .mist .photos { max-width: 100%; }
 }
 .mist .loadmore {
   align-self: flex-start;
@@ -561,6 +584,7 @@
   .mist .cursor,
   .mist .jpcaret,
   .mist .tcur,
+  .mist .headcaret,
   .mist .env .icon .rays {
     animation: none !important;
   }
@@ -607,7 +631,18 @@
   font-weight: 700;
   letter-spacing: -0.02em;
   line-height: 1;
+  min-height: 1em; /* タイプ前でも高さ確保（CLS 対策） */
   color: var(--m-ink);
+}
+/* タイトル打鍵中の細カーソル（ヒーローと同系） */
+.mist .pagehead .headcaret {
+  display: inline-block;
+  width: 3px;
+  height: 0.82em;
+  margin-left: 4px;
+  vertical-align: -0.08em;
+  background: var(--m-accent);
+  animation: m-pulseglow 1.1s steps(2) infinite;
 }
 .mist .pagehead .desc { margin: 9px 0 0; font-size: 12px; line-height: 1.7; color: var(--m-faint); }
 .mist .pagehead .actions { display: flex; align-items: center; gap: 10px; }

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -113,7 +113,7 @@ async function fetchTopPageData() {
       payload.count({ collection: 'media', where: GALLERY_WHERE }),
       payload.find({
         collection: 'media',
-        limit: 14,
+        limit: 20,
         sort: '-createdAt',
         where: GALLERY_WHERE,
       }),

--- a/src/components/mist/MistLogTimeline.tsx
+++ b/src/components/mist/MistLogTimeline.tsx
@@ -2,7 +2,7 @@
 // git log 風タイムライン（フィルタチップ・コミット列・load more・いいね）
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { type CSSProperties, useEffect, useMemo, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import ImageModal from '@/components/gallery/ImageModal'
@@ -120,6 +120,76 @@ function MistLike({ id, initialLikes }: { id: string | number; initialLikes: num
   )
 }
 
+/* ── 写真ブロック（X/Threads 方式の枚数別レイアウト） ─────────
+   1枚: Media の width/height から縦横比を算出し、縦画像は高さ基準で
+        トリミングせず表示。横画像は幅いっぱい・比率は最大16:9でクランプ。
+   2〜4枚: グリッドで object-cover。 */
+type TLImage = {
+  id?: string
+  image: {
+    id?: string
+    url: string
+    sizes?: Record<string, { url: string }>
+    width?: number | null
+    height?: number | null
+  }
+}
+
+function PhotoGrid({
+  photos,
+  title,
+  onOpen,
+}: {
+  photos: TLImage[]
+  title?: string | null
+  onOpen: (url: string) => void
+}) {
+  const items = photos.slice(0, 4)
+  const n = items.length
+  if (n === 0) return null
+  const cls = n === 1 ? 'one' : n === 2 ? 'two' : n === 3 ? 'three' : 'four'
+
+  return (
+    <div className={`photos ${cls}`}>
+      {items.map((imgObj) => {
+        const im = imgObj.image
+        const url = im.sizes?.thumbnail?.url ?? im.url
+        let style: CSSProperties | undefined
+        if (n === 1) {
+          const raw = im.width && im.height ? im.width / im.height : 1.4
+          const ratio = Math.min(Math.max(raw, 0.5), 16 / 9) // 極端な縦長/横長をクランプ
+          style =
+            ratio <= 1
+              ? // 縦/正方: 高さ最大500px基準で幅を算出（トリミングしない）
+                { width: Math.round(500 * ratio), maxWidth: '100%', aspectRatio: String(ratio) }
+              : // 横: 幅いっぱい・高さ上限500px
+                { width: '100%', aspectRatio: String(ratio), maxHeight: 500 }
+        }
+        return (
+          <button
+            key={imgObj.id || im.id || url}
+            type="button"
+            className="ph"
+            style={style}
+            aria-label="画像を拡大表示"
+            onClick={() => onOpen(im.url)}
+          >
+            <Image
+              src={toCFUrl(url)}
+              alt={title ?? 'timeline photo'}
+              fill
+              sizes={n === 1 ? '(max-width: 640px) 100vw, 640px' : '(max-width: 640px) 50vw, 320px'}
+              quality={75}
+              className="object-cover"
+              loading="lazy"
+            />
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
 /* ── 本体 ─────────────────────────────────── */
 
 type Props = {
@@ -179,7 +249,7 @@ export default function MistLogTimeline({ posts, total, showHead = true }: Props
       <div className="commits">
         {shown.map((post) => {
           const isHead = post.id === headId
-          const photos = (post.images ?? []).filter((img) => img?.image?.url).slice(0, 3)
+          const photos = (post.images ?? []).filter((img) => img?.image?.url).slice(0, 4)
           const typeLabel = post.postType ? TYPE_LABELS[post.postType] : null
           return (
             <article key={post.id} className={`commit ${isHead ? 'head' : ''}`}>
@@ -214,31 +284,7 @@ export default function MistLogTimeline({ posts, total, showHead = true }: Props
               )}
 
               {photos.length > 0 && (
-                <div className="photos">
-                  {photos.map((imgObj, i) => {
-                    const url = imgObj.image.sizes?.thumbnail?.url ?? imgObj.image.url
-                    return (
-                      <button
-                        key={imgObj.id || imgObj.image.id}
-                        type="button"
-                        className="ph"
-                        style={{ flex: i === 0 ? 1.5 : 1 }}
-                        aria-label="画像を拡大表示"
-                        onClick={() => setModalImg(imgObj.image.url)}
-                      >
-                        <Image
-                          src={toCFUrl(url)}
-                          alt={post.title ?? 'timeline photo'}
-                          fill
-                          sizes="(max-width: 640px) 50vw, 400px"
-                          quality={75}
-                          className="object-cover"
-                          loading="lazy"
-                        />
-                      </button>
-                    )
-                  })}
-                </div>
+                <PhotoGrid photos={photos} title={post.title} onOpen={setModalImg} />
               )}
 
               <MistLike id={post.id} initialLikes={post.likes ?? 0} />

--- a/src/components/mist/MistPageHead.tsx
+++ b/src/components/mist/MistPageHead.tsx
@@ -1,6 +1,9 @@
 // src/components/mist/MistPageHead.tsx
 // サブページ共通の見出し（ターミナル風プロンプト + 大型タイトル + 任意の説明/アクション）。
-import React from 'react'
+// タイトルはトップページのヒーローと同様にタイプライター表示で統一する。
+'use client'
+
+import React, { useEffect, useState } from 'react'
 
 type Props = {
   /** 例: 'cd ./posts' → `~/life $ cd ./posts` と表示 */
@@ -11,11 +14,43 @@ type Props = {
 }
 
 export default function MistPageHead({ cmd, title, desc, actions }: Props) {
+  const [typed, setTyped] = useState('')
+  const [done, setDone] = useState(false)
+
+  useEffect(() => {
+    const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    if (reduce) {
+      setTyped(title)
+      setDone(true)
+      return
+    }
+    setTyped('')
+    setDone(false)
+    let i = 0
+    const id = setInterval(() => {
+      i += 1
+      setTyped(title.slice(0, i))
+      if (i >= title.length) {
+        clearInterval(id)
+        setDone(true)
+      }
+    }, 65)
+    return () => clearInterval(id)
+  }, [title])
+
   return (
     <header className="pagehead">
       <div>
         <span className="cmd">~/life $ {cmd}</span>
-        <h1>{title}</h1>
+        {/* min-height（CSS）で空→タイプ完了まで高さ一定＝CLS 0。
+            表示はタイプ演出（aria-hidden）、SEO/AT 用に実タイトルを sr-only で常時保持 */}
+        <h1>
+          <span aria-hidden>
+            {typed}
+            {!done && <span className="headcaret" />}
+          </span>
+          <span className="sr-only">{title}</span>
+        </h1>
         {desc && <p className="desc jp">{desc}</p>}
       </div>
       {actions && <div className="actions">{actions}</div>}

--- a/src/components/mist/MistRail.tsx
+++ b/src/components/mist/MistRail.tsx
@@ -30,8 +30,8 @@ const MORE_LINKS = [
   { label: 'letter/', href: '/letter' },
 ] as const
 
-// 右レールに並べるギャラリーのサムネ枚数（残りは +n タイルに集約）
-const RAIL_THUMBS = 5
+// 右レールに並べるギャラリーのサムネ枚数（残りは +n タイルに集約。3列グリッド＝8枚+残数で3行）
+const RAIL_THUMBS = 8
 
 /** Spotify 共有URL → 埋め込みURL。playlist/album/track/artist に対応。不正なら null */
 function spotifyEmbedUrl(url?: string | null): string | null {


### PR DESCRIPTION
## Summary
フィードバック対応4点。写真の縦画像対応（X/Threads参照）、タイムライン/レールの幅再配分、サブページタイトルのタイプライター統一。

## Changes
- **写真レイアウト（X/Threads方式）**: `MistLogTimeline` の写真描画を枚数別に刷新。Media の `width`/`height` から縦横比を算出
  - **1枚**: 縦画像は高さ基準（最大500px）でトリミングせず表示、横画像は幅いっぱい・比率は最大16:9でクランプ、正方はそのまま
  - **2枚**: 2カラム（16:9）/ **3枚**: 左大＋右2段 / **4枚**: 2×2 グリッド（すべて `object-cover`）
- **レイアウト幅**: `.main` を `minmax(0,1fr) 380px` ＋ `max-width:1160px` に。タイムラインを読みやすい幅にキャップし、右レール（プロフィール/ギャラリー）を 320→**380px** に拡張。gallery サムネを 5→**8枚**、media 取得を 20 件に
- **タイトルのタイプ演出**: 各サブページの `Blog`/`Gallery` 等のタイトルをヒーローと同じタイプライター表示に統一（`MistPageHead`）。SEO/AT 用に実タイトルを `sr-only` で常時保持、`min-height` で CLS 抑制

## Test Plan
- [x] `tsc --noEmit` / `pnpm build`（全ルート）/ `pnpm lint` クリーン
- [x] プレレンダ確認: 単写真=`photos one`（比率算出）/ 2枚=`photos two`、レール8タイル、サブページ h1 に `sr-only` 実タイトル＋タイプ用カーソル
- [ ] Vercel プレビューで縦画像・横画像・2〜4枚投稿の見え方、タイムライン幅/レール幅、各ページタイトルのタイプ演出を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)