### PR TITLE
feat(sp): SP構成（件数間引き・Navハンバーガー・コンパクト紹介・行長680px）[Prompt2 D]

### DIFF
--- a/src/app/(frontend)/mist.css
+++ b/src/app/(frontend)/mist.css
@@ -150,24 +150,68 @@
 }
 /* 見た目を変えずヒット領域だけ縦に拡張し 44px 以上に（横は隣接のため触らない） */
 .mist .nav a::after { content: ''; position: absolute; inset: -10px 0; }
+/* ハンバーガーボタン（PC では非表示。SP で nav をドロップダウンに畳む） */
+.mist .navtoggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 11px;
+  border: 1px solid var(--m-hairline);
+  background: var(--m-surface);
+  color: var(--m-ink);
+  font-size: var(--fs-ui);
+  line-height: 1;
+  cursor: pointer;
+}
 @media (max-width: 760px) {
-  .mist .navwrap::before,
-  .mist .navwrap::after {
-    content: '';
+  .mist .navtoggle { display: inline-flex; }
+  /* 既定は閉（非表示）。開くと titlebar 直下に $ ls ./nav 風ドロップダウン */
+  .mist .nav { display: none; }
+  .mist .navwrap .nav.open {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
     position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 22px;
-    pointer-events: none;
-    z-index: 1;
+    top: calc(100% + 9px);
+    right: 0;
+    z-index: 30;
+    min-width: 190px;
+    padding: 6px;
+    margin: 0;
+    overflow: visible;
+    background: var(--m-surface);
+    backdrop-filter: blur(14px);
+    border: 1px solid var(--m-hairline);
+    box-shadow: 0 10px 30px color-mix(in oklch, var(--m-ink) 12%, transparent);
   }
-  .mist .navwrap::before { left: 0; background: linear-gradient(to right, rgba(244, 246, 249, 0.95), transparent); }
-  .mist .navwrap::after { right: 0; background: linear-gradient(to left, rgba(244, 246, 249, 0.95), transparent); }
+  /* 縦積みのため ::after(縦±10px) は隣接項目と重なる → 無効化し padding でタップ領域を確保 */
+  .mist .nav.open a { padding: 12px 14px; }
+  .mist .nav.open a::after { content: none; }
 }
 .mist .nav a.on,
 .mist .nav a:active { background: var(--m-ink); color: #fff; }
 @media (hover: hover) {
   .mist .nav a:hover { background: var(--m-ink); color: #fff; }
+}
+
+/* ── コンパクト自己紹介（D-1 案2・SP のみ表示。フルの profile カードは現位置に残す） ── */
+.mist .compact-intro { display: none; }
+@media (max-width: 760px) {
+  .mist .compact-intro {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 12px var(--m-pad) 0;
+    padding: 8px 12px;
+    background: var(--m-surface);
+    border: 1px solid var(--m-hairline);
+  }
+  .mist .ci-av { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; border: 1px solid var(--m-hairline); flex: none; }
+  .mist .ci-meta { display: flex; flex-direction: column; min-width: 0; }
+  .mist .ci-nm { font-weight: 700; font-size: var(--fs-ui); color: var(--m-ink); line-height: 1.2; }
+  .mist .ci-rl { font-size: var(--fs-caption); color: var(--m-faint); }
+  .mist .ci-sns { display: flex; gap: 6px; margin-left: auto; flex: none; }
+  .mist .ci-sns a { font-size: var(--fs-caption); color: var(--m-sub); border: 1px solid var(--m-hairline); padding: 6px 8px; text-decoration: none; line-height: 1; }
 }
 
 /* ── hero ─────────────────────────────────── */
@@ -607,12 +651,15 @@
 }
 
 /* ── SP 出し分け（D-4）: DOM はPC分をレンダリングし、SPは display:none で間引く。
-   Home の対象画像は loading="lazy" のため非表示分は取得されず転送量は増えない。
+   非表示分の Next <Image loading="lazy"> は display:none でレイアウトボックスを持たず
+   ビューポート交差判定に掛からないため取得されない（転送量は増えない）。
    閾値は既存の 760px（homecols 縦積み点）を再利用。 */
 @media (max-width: 760px) {
-  /* タイムライン: PC 6 / SP 3（4件目以降を非表示。load --more の全件導線は維持） */
-  .mist .commits .commit:nth-child(n + 4) { display: none; }
-  /* ギャラリー: PC 9(big維持) / SP 6（big解除で等サイズ 2×3、7枚目以降を非表示） */
+  /* タイムライン（Home のダイジェストのみ。.homecols で限定し、専用 /timeline には効かせない）
+     PC 6 / SP 3（4件目以降を非表示。load --more の全件導線は維持） */
+  .mist .homecols .commits .commit:nth-child(n + 4) { display: none; }
+  /* ギャラリー（Home）: 2列固定で 6枚=2×3 を全帯域で成立させる（auto-fill だと ~615-760px で4列になり最終行が欠ける） */
+  .mist .gal { grid-template-columns: repeat(2, 1fr); }
   .mist .gal .g.big { grid-column: span 1; grid-row: span 1; }
   .mist .gal .g:nth-child(n + 7) { display: none; }
 }
@@ -860,7 +907,8 @@
 .mist .formnote { font-size: var(--fs-meta); color: var(--m-faint); }
 
 /* 記事詳細（posts/[slug]） */
-.mist .article { width: 100%; max-width: 760px; margin: 0 auto; }
+/* D-3: 本文行長を約42字/行に（prose 16px × 680px）。日本語可読の目安 35〜45字内 */
+.mist .article { width: 100%; max-width: 680px; margin: 0 auto; }
 .mist .article .cover { position: relative; width: 100%; aspect-ratio: 16 / 9; overflow: hidden; border: 1px solid var(--m-hairline); margin-bottom: 22px; }
 .mist .article h1 { margin: 0 0 8px; font-family: var(--font-outfit), sans-serif; font-size: clamp(24px, 3.6vw, 32px); font-weight: 700; letter-spacing: -0.02em; line-height: 1.25; color: var(--m-ink); }
 .mist .article .amETA,

--- a/src/app/(frontend)/mist.css
+++ b/src/app/(frontend)/mist.css
@@ -215,12 +215,12 @@
   }
   .mist .ci-av { position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; border: 1px solid var(--m-hairline); flex: none; }
   .mist .ci-meta { display: flex; flex-direction: column; min-width: 0; }
-  .mist .ci-nm { font-weight: 700; font-size: var(--fs-ui); color: var(--m-ink); line-height: 1.2; }
+  .mist .ci-nm { font-weight: 700; font-size: var(--fs-ui); color: var(--m-ink); line-height: 1.2; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .mist .ci-rl { font-size: var(--fs-caption); color: var(--m-faint); }
   .mist .ci-sns { display: flex; gap: 6px; margin-left: auto; flex: none; }
   .mist .ci-sns a { position: relative; font-size: var(--fs-caption); color: var(--m-sub); border: 1px solid var(--m-hairline); padding: 6px 8px; text-decoration: none; line-height: 1; }
-  /* 見た目を変えずヒット領域を 44px 相当に拡張 */
-  .mist .ci-sns a::after { content: ''; position: absolute; inset: -10px -4px; }
+  /* 見た目を変えずヒット領域を縦に拡張（横は gap 6px を超えないよう ±3px に留め隣接と重ねない） */
+  .mist .ci-sns a::after { content: ''; position: absolute; inset: -12px -3px; }
 }
 
 /* ── hero ─────────────────────────────────── */

--- a/src/app/(frontend)/mist.css
+++ b/src/app/(frontend)/mist.css
@@ -605,6 +605,17 @@
 @media (hover: hover) {
   .mist .gal .g:hover { filter: brightness(0.94); }
 }
+
+/* ── SP 出し分け（D-4）: DOM はPC分をレンダリングし、SPは display:none で間引く。
+   Home の対象画像は loading="lazy" のため非表示分は取得されず転送量は増えない。
+   閾値は既存の 760px（homecols 縦積み点）を再利用。 */
+@media (max-width: 760px) {
+  /* タイムライン: PC 6 / SP 3（4件目以降を非表示。load --more の全件導線は維持） */
+  .mist .commits .commit:nth-child(n + 4) { display: none; }
+  /* ギャラリー: PC 9(big維持) / SP 6（big解除で等サイズ 2×3、7枚目以降を非表示） */
+  .mist .gal .g.big { grid-column: span 1; grid-row: span 1; }
+  .mist .gal .g:nth-child(n + 7) { display: none; }
+}
 .mist .gal .g em {
   position: absolute; left: 8px; bottom: 8px; z-index: 1;
   font-style: normal; font-size: var(--fs-caption); color: var(--m-sub);

--- a/src/app/(frontend)/mist.css
+++ b/src/app/(frontend)/mist.css
@@ -116,6 +116,10 @@
   border-bottom: 1px solid var(--m-hairline);
   background: var(--m-surface);
   backdrop-filter: blur(14px);
+  /* backdrop-filter がスタッキングコンテキストを作るため、ナビのドロップダウン(子)を
+     後続の hero/env(position:relative / backdrop-filter)より前面に出すには titlebar 自体を持ち上げる */
+  position: relative;
+  z-index: 10;
 }
 .mist .dots { display: flex; gap: 7px; flex: none; }
 .mist .dots span {
@@ -153,6 +157,7 @@
 /* ハンバーガーボタン（PC では非表示。SP で nav をドロップダウンに畳む） */
 .mist .navtoggle {
   display: none;
+  position: relative;
   align-items: center;
   justify-content: center;
   padding: 7px 11px;
@@ -163,6 +168,8 @@
   line-height: 1;
   cursor: pointer;
 }
+/* 見た目を変えずヒット領域を 44px 以上に拡張 */
+.mist .navtoggle::after { content: ''; position: absolute; inset: -4px -8px; }
 @media (max-width: 760px) {
   .mist .navtoggle { display: inline-flex; }
   /* 既定は閉（非表示）。開くと titlebar 直下に $ ls ./nav 風ドロップダウン */
@@ -211,7 +218,9 @@
   .mist .ci-nm { font-weight: 700; font-size: var(--fs-ui); color: var(--m-ink); line-height: 1.2; }
   .mist .ci-rl { font-size: var(--fs-caption); color: var(--m-faint); }
   .mist .ci-sns { display: flex; gap: 6px; margin-left: auto; flex: none; }
-  .mist .ci-sns a { font-size: var(--fs-caption); color: var(--m-sub); border: 1px solid var(--m-hairline); padding: 6px 8px; text-decoration: none; line-height: 1; }
+  .mist .ci-sns a { position: relative; font-size: var(--fs-caption); color: var(--m-sub); border: 1px solid var(--m-hairline); padding: 6px 8px; text-decoration: none; line-height: 1; }
+  /* 見た目を変えずヒット領域を 44px 相当に拡張 */
+  .mist .ci-sns a::after { content: ''; position: absolute; inset: -10px -4px; }
 }
 
 /* ── hero ─────────────────────────────────── */

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -15,6 +15,7 @@ import MistLogTimeline from '@/components/mist/MistLogTimeline'
 import MistGallery from '@/components/mist/MistGallery'
 import MistPortalSection, { type PortalItem } from '@/components/mist/MistPortalSection'
 import MistRail from '@/components/mist/MistRail'
+import MistCompactIntro from '@/components/mist/MistCompactIntro'
 import type { TimelineDoc, MediaDoc, BlogPost, Event, Product } from '@/lib/payloadTypes'
 import { OG_IMAGE, OG_IMAGE_URL } from '@/lib/seo'
 
@@ -344,6 +345,9 @@ export default async function Home() {
           <header className="hero">
             <MistHero tagline={hero.tagline} role={hero.role} />
           </header>
+
+          {/* SP のみ: hero 直下のコンパクト自己紹介（D-1 案2） */}
+          <MistCompactIntro profile={profile} />
 
           {/* ── 統合バー: NOTICE ローテ + entries/photos/streak + 天気/時計 ── */}
           <MistStatusBar

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -140,7 +140,7 @@ async function fetchTopPageData() {
     productsRes,
   ] = await Promise.all([
       // Home は直近10件のダイジェスト（全件は専用の /timeline タブで）
-      payload.find({ collection: 'timeline', limit: 10, sort: '-publishedAt', depth: 2 }),
+      payload.find({ collection: 'timeline', limit: 6, sort: '-publishedAt', depth: 2 }),
       // 集計用は日付だけを軽量に取得（streak計算）
       payload.find({
         collection: 'timeline',

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -140,7 +140,7 @@ async function fetchTopPageData() {
     eventsRes,
     productsRes,
   ] = await Promise.all([
-      // Home は直近10件のダイジェスト（全件は専用の /timeline タブで）
+      // Home は直近6件のダイジェスト（全件は専用の /timeline タブで）
       payload.find({ collection: 'timeline', limit: 6, sort: '-publishedAt', depth: 2 }),
       // 集計用は日付だけを軽量に取得（streak計算）
       payload.find({

--- a/src/components/mist/MistCompactIntro.tsx
+++ b/src/components/mist/MistCompactIntro.tsx
@@ -1,0 +1,56 @@
+// src/components/mist/MistCompactIntro.tsx
+// SP 専用のコンパクト自己紹介（D-1 案2）。hero 直下に「小アバター + 名前 + role + SNS」を1行で。
+// 「誰のサイトか」をファーストビュー近くで示す。フルの profile カード（MistRail）は現位置に残す。
+// 表示は CSS（.compact-intro）で ≤760px のみ。
+import Image from 'next/image'
+import { toCFUrl } from '@/lib/cfUrl'
+
+type ProfileData = {
+  name?: string | null
+  nameJapanese?: string | null
+  title?: string | null
+  imageUrl?: string | null
+  socialLinks?: { platform?: string | null; url?: string | null; displayName?: string | null }[]
+}
+
+const PLATFORM_LABELS: Record<string, string> = {
+  twitter: 'x',
+  instagram: 'ig',
+  github: 'gh',
+  linkedin: 'in',
+  youtube: 'yt',
+}
+
+export default function MistCompactIntro({ profile }: { profile: ProfileData }) {
+  const name = profile.nameJapanese ?? profile.name
+  if (!name && !profile.imageUrl) return null
+
+  return (
+    <div className="compact-intro" aria-label="プロフィール概要">
+      {profile.imageUrl && (
+        <div className="ci-av">
+          <Image
+            src={toCFUrl(profile.imageUrl)}
+            alt={name ?? 'avatar'}
+            fill
+            sizes="34px"
+            className="object-cover"
+          />
+        </div>
+      )}
+      <div className="ci-meta">
+        <span className="ci-nm jp">{name}</span>
+        {profile.title && <span className="ci-rl">{profile.title}</span>}
+      </div>
+      <div className="ci-sns">
+        {profile.socialLinks?.map(({ platform, url, displayName }) =>
+          url ? (
+            <a key={url} href={url} target="_blank" rel="noopener noreferrer" aria-label={displayName ?? platform ?? 'link'}>
+              {displayName?.toLowerCase() || (platform ? PLATFORM_LABELS[platform] : null) || '↗'}
+            </a>
+          ) : null,
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/mist/MistCompactIntro.tsx
+++ b/src/components/mist/MistCompactIntro.tsx
@@ -43,7 +43,8 @@ export default function MistCompactIntro({ profile }: { profile: ProfileData }) 
         {profile.title && <span className="ci-rl">{profile.title}</span>}
       </div>
       <div className="ci-sns">
-        {profile.socialLinks?.map(({ platform, url, displayName }) =>
+        {/* コンパクト行なので最大4件に制限（全件はフルの profile カードに表示） */}
+        {profile.socialLinks?.slice(0, 4).map(({ platform, url, displayName }) =>
           url ? (
             <a key={url} href={url} target="_blank" rel="noopener noreferrer" aria-label={displayName ?? platform ?? 'link'}>
               {displayName?.toLowerCase() || (platform ? PLATFORM_LABELS[platform] : null) || '↗'}

--- a/src/components/mist/MistTitlebar.tsx
+++ b/src/components/mist/MistTitlebar.tsx
@@ -51,14 +51,15 @@ export default function MistTitlebar() {
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false)
-    const onClick = (e: MouseEvent) => {
+    // iOS Safari は非インタラクティブ要素への click を発火しないため pointerdown で外側判定
+    const onDown = (e: Event) => {
       if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false)
     }
     document.addEventListener('keydown', onKey)
-    document.addEventListener('click', onClick)
+    document.addEventListener('pointerdown', onDown)
     return () => {
       document.removeEventListener('keydown', onKey)
-      document.removeEventListener('click', onClick)
+      document.removeEventListener('pointerdown', onDown)
     }
   }, [open])
 

--- a/src/components/mist/MistTitlebar.tsx
+++ b/src/components/mist/MistTitlebar.tsx
@@ -28,9 +28,12 @@ export default function MistTitlebar() {
   const pathname = usePathname() ?? '/'
   // SSRとの不一致を避けるためマウント後に時計を開始する（秒なし・30s 更新）
   const [time, setTime] = useState('--:--')
-  // SPでナビが横スクロールするため、アクティブ項目を画面内（中央）へ寄せて存在を可視化
+  // SP: ハンバーガーメニューの開閉
+  const [open, setOpen] = useState(false)
+  // PC でナビがはみ出す場合にアクティブ項目を中央へ寄せる
   const activeRef = useRef<HTMLAnchorElement>(null)
   const navRef = useRef<HTMLElement>(null)
+  const wrapRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const nav = navRef.current
@@ -40,6 +43,24 @@ export default function MistTitlebar() {
     const target = active.offsetLeft - (nav.clientWidth - active.clientWidth) / 2
     nav.scrollLeft = Math.max(0, target)
   }, [pathname])
+
+  // ページ遷移でメニューを閉じる
+  useEffect(() => setOpen(false), [pathname])
+
+  // 開いている間は Escape / 外側クリックで閉じる
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false)
+    const onClick = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('click', onClick)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('click', onClick)
+    }
+  }, [open])
 
   useEffect(() => {
     const fmt = () => {
@@ -62,8 +83,22 @@ export default function MistTitlebar() {
       <span className="tb-path max-sm:hidden">
         makoto@tokyo: ~/life — <span suppressHydrationWarning>{time}</span>
       </span>
-      <div className="navwrap">
-        <nav className="nav" aria-label="メインナビゲーション" ref={navRef}>
+      <div className="navwrap" ref={wrapRef}>
+        {/* SP: ハンバーガー（PC では CSS で非表示）。開くと $ ls ./nav 風のドロップダウン */}
+        <button
+          type="button"
+          className="navtoggle"
+          aria-label={open ? 'メニューを閉じる' : 'メニューを開く'}
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+        >
+          {open ? '✕' : '☰'}
+        </button>
+        <nav
+          className={`nav${open ? ' open' : ''}`}
+          aria-label="メインナビゲーション"
+          ref={navRef}
+        >
           {NAV.map(({ label, href }) => {
             const on = isActive(pathname, href)
             return (
@@ -73,6 +108,7 @@ export default function MistTitlebar() {
                 ref={on ? activeRef : undefined}
                 className={on ? 'on' : undefined}
                 aria-current={on ? 'page' : undefined}
+                onClick={() => setOpen(false)}
               >
                 {label}
               </Link>


### PR DESCRIPTION
## Summary
デザインシステム統合の第3弾（論理単位③=SP構成）。SP のファーストビューと操作性を改善。PC(>760px)の3ゾーン構成・見た目は不変。DOM は常にPC分をレンダリングし、SP は CSS `display:none` で出し分け（JS matchMedia なし＝hydration/CLS 回避）。Fable 5 レビュー済み（Blocking 1・Should-fix 2 対応）。

## 変更
### D-4a/D-4b — 件数間引き（確定仕様）
- タイムライン: Home 取得 `limit 6`。SP は `.homecols .commits .commit:nth-child(n+4)` を display:none（Home限定・専用/timelineには非適用）。PC6/SP3。`load --more` 導線維持。
- ギャラリー: PC9(先頭 big=2×2 維持)。SP は `.gal` 2列固定＋big解除＋7枚目以降 display:none → 6枚(2×3)。`GRID_COUNT=9` のまま・CSSのみ。
- 非表示分の `<Image loading="lazy">` は取得されず転送量は増えない。

### Nav ハンバーガー化（D-2 を「間引き」から変更）
- SP(≤760px)で nav を `☰` に畳み、タップで titlebar 直下ドロップダウンに**全8項目**を表示（間引かず全アクセス維持）。遷移/Escape/外側 pointerdown/項目タップで閉。PC は横並び維持。旧・横スクロールのフェード示唆は撤去。

### D-1（案2）— hero下コンパクト自己紹介
- hero 直下に SP 専用の1行紹介（小アバター+名前+role+SNS）を追加し「誰のサイトか」を近くで提示。フルの profile カードは現位置に残す。`MistCompactIntro` 新規、表示は `.compact-intro` で ≤760px のみ。

### D-3 — 記事行長
- `.article max-width` 760→680px（prose 16px×680≒42字/行、日本語可読の目安 35〜45字内）。

## Fable 5 対応
- **Blocking**: `.titlebar` の backdrop-filter がスタッキングコンテキストを作りドロップダウンが hero/env の下に潜って項目タップ不能 → `position:relative; z-index:10` で解消。
- **Should-fix**: 外側クリックを `pointerdown` に（iOS Safari 対策）／`.navtoggle`・`.ci-sns a` のタップ領域を 44px 相当へ。

## Test Plan
- [x] `tsc` / `pnpm build` / `pnpm lint` クリーン
- [x] DOM=PC分（Home 6 commits / gallery 9 tiles）、SP出し分けは CSS、`.homecols` で /timeline 非漏洩
- [ ] iOS/Android 実機: ハンバーガー開閉（遷移/Escape/外側/項目）、ドロップダウンが前面でタップ可、コンパクト紹介の表示、SP件数(3/6)、記事行長

（後続 PR: ④余白 C）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * モバイルでナビゲーションをハンバーガーメニューに切り替え、開閉できるようになりました。
  * スマホ向けに、よりコンパクトな自己紹介セクションが表示されるようになりました。

* **改善**
  * スマホ表示でタイムラインやギャラリーの表示密度を調整し、見やすさを向上しました。
  * 記事本文の横幅を見直し、読みやすくしました。
  * トップページの表示件数を調整し、より厳選された内容を表示するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->