### PR TITLE
docs: READMEのDB記述をPostgresに修正（PRフロー疎通テスト）

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This template comes configured with the bare minimum to get started on anything 
 
 ## Quick start
 
-This template can be deployed directly from our Cloud hosting and it will setup MongoDB and cloud S3 object storage for media.
+This template can be deployed directly from our Cloud hosting and it will setup a Postgres database and cloud S3 object storage for media.
 
 ## Quick Start - local setup
 
@@ -17,7 +17,7 @@ After you click the `Deploy` button above, you'll want to have standalone copy o
 ### Development
 
 1. First [clone the repo](#clone) if you have not done so already
-2. `cd my-project && cp .env.example .env` to copy the example environment variables. You'll need to add the `MONGODB_URI` from your Cloud project to your `.env` if you want to use S3 storage and the MongoDB database that was created for you.
+2. `cd my-project && cp .env.example .env` to copy the example environment variables. You'll need to add the `POSTGRES_URL` from your Cloud project to your `.env` if you want to use S3 storage and the Postgres database that was created for you.
 
 3. `pnpm install && pnpm dev` to install dependencies and start the dev server
 4. open `http://localhost:3000` to open the app in your browser


### PR DESCRIPTION
## 概要
gh CLI / git 認証セットアップ後の **PR作成フロー疎通テスト** を兼ねた軽微なドキュメント修正です。

## 変更内容
Payloadテンプレート由来の記述に MongoDB が残っていたため、実装で使用している **Postgres**（`@payloadcms/db-vercel-postgres` / `POSTGRES_URL`）に合わせて修正しました（README 2箇所）。

- `MongoDB` → `a Postgres database`
- `MONGODB_URI` → `POSTGRES_URL`

## 動作確認（実env込み・ローカル）
CLAUDE.md の手順に従い、本番相当の `.env` を適用して検証済み:

- ✅ `pnpm generate:types` … 成功（型差分なし）
- ✅ `pnpm build` … 成功（sitemap生成まで完走 / `/timeline` 含む全ページ生成OK）
- ✅ `pnpm lint` … 成功（警告のみ・エラーなし）

コード挙動には影響しないドキュメントのみの変更です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)