### PR TITLE
chore: env系ファイルを.gitignoreで網羅的に除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,10 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env*.local
+# local env files (keep .env.example tracked)
+.env
+.env*
+!.env.example
 
 # vercel
 .vercel
@@ -37,9 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-
-.env
-
 
 # next-sitemap の生成物（postbuildで毎回生成されるためコミットしない）
 public/sitemap*.xml


### PR DESCRIPTION
## 背景
`.env.incoming`（本番相当のsecretを含む）が `.gitignore` の対象外で、`git add .` 等で誤ってコミット・pushしてしまうリスクがありました。

## 変更内容
`.env*` をまとめて除外し、`.env.example` のみ追跡を維持するよう修正。

```diff
-# local env files
-.env*.local
+# local env files (keep .env.example tracked)
+.env
+.env*
+!.env.example
```
（末尾に重複していた単独 `.env` 行も削除）

## 検証（`git check-ignore`）
| ファイル | 判定 |
|---|---|
| `.env` / `.env.incoming` / `.env.production` / `.env.local` | ✅ IGNORED |
| `.env.example` | ✅ TRACKED（追跡維持） |

ドキュメント/設定のみの変更で、アプリ挙動・ビルドには影響しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)