### PR TITLE
fix(sp): 環境バーをミニマル3行に再構築（NOTICE / stats / 天気・時計）

### DIFF
--- a/src/app/(frontend)/mist.css
+++ b/src/app/(frontend)/mist.css
@@ -337,6 +337,8 @@
   animation: m-pulseglow 1.1s steps(2) infinite;
 }
 .mist .divider { width: 1px; align-self: stretch; background: var(--m-hairline); }
+/* stats ラッパは PC では透過（display:contents）し従来の横並びを維持、SP のみ独立行にまとめる */
+.mist .env .stats { display: contents; }
 .mist .env .kv { color: var(--m-faint); }
 .mist .env .kv b { color: var(--m-ink-2); font-weight: 600; }
 .mist .env .vals {
@@ -366,34 +368,62 @@
   text-underline-offset: 2px;
 }
 
-/* SP: 環境バーが時間帯（＝可変長の NOTICE メッセージ）で段組みが揺れて2段化するのを防ぐ。
-   要素は削らず、NOTICE / stats / 天気・時計 をそれぞれ独立行に整列した安定レイアウトにする。
-   長い NOTICE メッセージは省略記号で丸め、他要素を押し出さない。 */
+/* SP: 環境バーを 3 行（NOTICE / stats / 天気・時計）に整列した安定レイアウトへ。
+   各行は高さ固定・1行完結で、時間帯（＝可変長の NOTICE メッセージ）による段組みの
+   揺れや 2 段化を防ぐ。長い値は末尾…で丸め、他要素を押し出さない。 */
 @media (max-width: 760px) {
-  .mist .env { gap: 8px 12px; }
+  .mist .env { gap: 8px 12px; padding: 10px 14px; }
   .mist .env .divider { display: none; } /* 縦罫線は横並び前提のため段組みでは不要 */
-  .mist .env .cmd { flex-basis: 100%; min-width: 0; align-items: flex-start; } /* NOTICE を独立行に（上揃え） */
-  /* NOTICE ラベル＋日付＋メッセージ全体を最大2行にクランプし、常に2行分の高さを確保。
-     短文でも高さが変わらず、長文でも他要素を押さないため段組みが時間帯で揺れない。 */
+
+  /* ── Row 1: NOTICE（1行・末尾…で省略。高さ固定でガタつかない） ── */
+  .mist .env .cmd { flex-basis: 100%; min-width: 0; }
   .mist .env .rotwrap {
     flex: 1 1 auto;
     min-width: 0;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
+    flex-wrap: nowrap;
     overflow: hidden;
-    min-height: 3em; /* line-height 1.5 × 2 行 */
-    line-height: 1.5;
   }
-  /* -webkit-box では gap が無効なので要素間隔を margin で確保 */
-  .mist .env .rotwrap .ndate,
-  .mist .env .rotwrap .jp { margin-left: 6px; }
-  .mist .env .vals { flex-basis: 100%; margin-left: 0; } /* 天気・時計を独立行に（右寄せ解除） */
-  .mist .env .sep { display: none; } /* 区切り「|」は段組みでは行境界が担うため非表示 */
-  /* 天気ラベル・地名は内部改行させず、収まらなければ .dt を丸ごと次行へ。
-     地名が極端に長い場合は .wx 自体が縮んで末尾…（横溢れ防止） */
+  /* 日付バッジは通常 flex-shrink:0。想定外に長い badge が来ても他要素を押さないよう上限を設ける */
+  .mist .env .ndate { max-width: 40%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .mist .env .rotwrap .jp {
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .mist .env .tcur { display: none; } /* 省略記号と役割が重複するため非表示 */
+
+  /* ── Row 2: stats（entries / photos / streak を中黒区切りで1行に） ──
+     3つの .kv を .stats で束ね、折返し時に行頭へ中黒が出るのを構造的に防ぐ。
+     溢れる場合は行末をクリップ（中黒が行頭に来ない）。 */
+  .mist .env .stats {
+    display: flex;
+    flex-basis: 100%;
+    gap: 12px;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+  .mist .env .kv + .kv::before {
+    content: '·';
+    margin: 0 8px 0 -4px; /* 列 gap 12px と合わせて中黒の左右間隔をほぼ均等に */
+    color: var(--m-line);
+  }
+
+  /* ── Row 3: 天気（左）＋ 日時（右）を同一行に ── */
+  /* nowrap で固定要素（アイコン/気温/日時）は改行させず、可変長の .wx（天気ラベル・地名）
+     だけを縮めて末尾…にすることで、幅に依らず必ず1行を維持し 2 段化を防ぐ。 */
+  .mist .env .vals { flex-basis: 100%; margin-left: 0; flex-wrap: nowrap; gap: 4px 8px; }
+  .mist .env .icon,
+  .mist .env .temp { flex-shrink: 0; } /* アイコン・気温は縮めない（縮むのは .wx のみ） */
+  .mist .env .sep { display: none; } /* 区切り「|」は行境界が担うため非表示 */
   .mist .env .wx { white-space: nowrap; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+  /* MET Norway 帰属表示は法的要件のため残す。要素内改行を禁止し行を崩さない（稀な met.no 時のみ出現） */
+  .mist .env .attribution { white-space: nowrap; flex-shrink: 0; }
+  .mist .env .dt { margin-left: auto; flex-shrink: 0; } /* 日時を右端へ寄せる */
+  .mist .env .date .yr,
+  .mist .env .date .wd { display: none; } /* SP は MM.DD のみ（年・曜日は省略） */
 }
 
 /* ── main: [content] + 右端固定プロフィール（フルブリード幅） ─────────── */

--- a/src/components/mist/MistStatusBar.tsx
+++ b/src/components/mist/MistStatusBar.tsx
@@ -188,14 +188,17 @@ export default function MistStatusBar({ notices, entries, photos, streak }: Prop
       </span>
 
       <span className="divider" aria-hidden />
-      <span className="kv">
-        entries: <b>{entries}</b>
-      </span>
-      <span className="kv">
-        photos: <b>{photos}</b>
-      </span>
-      <span className="kv">
-        streak: <b>{streak}d</b>
+      {/* stats: PC は display:contents で従来の横並び、SP は .stats で独立行にまとめる */}
+      <span className="stats">
+        <span className="kv">
+          entries: <b>{entries}</b>
+        </span>
+        <span className="kv">
+          photos: <b>{photos}</b>
+        </span>
+        <span className="kv">
+          streak: <b>{streak}d</b>
+        </span>
       </span>
 
       <span className="vals">
@@ -224,9 +227,15 @@ export default function MistStatusBar({ notices, entries, photos, streak }: Prop
         {/* 日付＋時刻は1つの折返し単位（.dt）にまとめ、SPで時刻だけが単独でぶら下がるのを防ぐ */}
         <span className="dt">
           <span className="date" suppressHydrationWarning>
-            {now
-              ? `${now.getFullYear()}.${pad(now.getMonth() + 1)}.${pad(now.getDate())} ${DAYS[now.getDay()]}`
-              : ''}
+            {now ? (
+              <>
+                <span className="yr">{now.getFullYear()}.</span>
+                {pad(now.getMonth() + 1)}.{pad(now.getDate())}
+                <span className="wd"> {DAYS[now.getDay()]}</span>
+              </>
+            ) : (
+              ''
+            )}
           </span>
           <span className="time" suppressHydrationWarning>
             {now ? `${pad(now.getHours())}:${pad(now.getMinutes())}` : '--:--'}


### PR DESCRIPTION
## 背景
SP幅で環境バー（`.env` / MistStatusBar）の表示が崩れていた:
- NOTICE が常に2行分の高さ（`min-height:3em`）を確保し、短文でも空白の2行になり不格好
- 天気・時計行が要素過多で折り返し「2段化」

## 変更（ミニマル3行レイアウト）
ユーザー合意のもと、要素は削らず安定した3行に整列。

| 行 | 内容 |
|---|---|
| Row1 | NOTICE を**1行・末尾…省略**で高さ固定（空白2行を解消） |
| Row2 | entries・photos・streak を**中黒区切りで1行**（`.stats` でラップ、折返し時の行頭中黒も構造的に防止） |
| Row3 | **天気(左)＋日時(右)** を `nowrap` で必ず1行維持。SPは日付を **MM.DD** に短縮（年・曜日を省略） |

- 稀な **MET Norway 帰属表示**は要素内改行を禁止し行崩れを防止（法的表示として維持）
- **デスクトップは無影響**: `.stats { display: contents }` で透過し従来の横並びを維持

## レビュー / 検証
- **Fable 5 レビュー**実施 → Blocking（Row3 の nowrap 化）＋ Should-fix（attribution / stats折返し / ndate上限）を反映
- SP実機（iPhone / tailnet プレビュー）で表示確認済み
- `pnpm lint` / `pnpm build` 通過

変更は `@media (max-width:760px)` と SP専用マークアップに限定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * スマホ表示の環境バーを3行構成に見直し、NOTICE・統計・天気/日時が見やすく整理されました。
  * 日付表示を年・月・日・曜日ごとに扱えるようになり、表示の柔軟性が向上しました。

* **改善**
  * PC表示では統計欄の横並びレイアウトを維持しつつ、余白や折り返しを調整しました。
  * 文字数が多い場合でも、NOTICEや天気情報がはみ出しにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->