### PR TITLE
feat: LINEからTimelineへ投稿するwebhook (Refs #35)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
 # Added by Payload
 PAYLOAD_SECRET=94759eda146d44e878b4b486
 POSTGRES_URL=postgres://postgres:<password>@127.0.0.1:5432/
+
+# LINE から Timeline へ投稿する webhook 用（Issue #35）
+# LINE Developers コンソールの Messaging API チャネルから取得
+LINE_CHANNEL_SECRET=
+LINE_CHANNEL_ACCESS_TOKEN=
+# 投稿を許可する自分の LINE userId（カンマ区切りで複数可）
+LINE_ALLOWED_USER_ID=

--- a/docs/LINE_TIMELINE_SETUP.md
+++ b/docs/LINE_TIMELINE_SETUP.md
@@ -1,0 +1,63 @@
+# LINE から Timeline へ投稿する機能 — セットアップ手順（Issue #35）
+
+LINE のトーク画面にテキストを送ると、サイトの **Timeline** に投稿され、投稿確認がリッチメッセージ（Flex）で返ってくる機能です。投稿できるのは**自分の LINE アカウントのみ**（userId ホワイトリスト）。
+
+コード側（webhook・投稿処理・確認メッセージ）は実装済みです。**動かすには以下のユーザー操作が必要**です。
+
+---
+
+## 🧑‍💻 あなたの実施が必要な作業
+
+### 1. LINE Messaging API チャネルを用意
+[LINE Developers コンソール](https://developers.line.biz/console/) で、Messaging API チャネルを作成（既存の Bot を流用してもよい）。
+
+- **チャネルシークレット**（Basic settings）→ `LINE_CHANNEL_SECRET`
+- **チャネルアクセストークン（long-lived）**（Messaging API タブで発行）→ `LINE_CHANNEL_ACCESS_TOKEN`
+- 応答設定: **「応答メッセージ」を OFF**、**「Webhook」を ON** にする
+
+### 2. 自分の LINE userId を調べる → `LINE_ALLOWED_USER_ID`
+userId は「Uxxxxxxxx…」の形式（LINE の表示名や ID とは別物）。取得方法の例:
+- 一旦 `LINE_ALLOWED_USER_ID` を仮値にしてデプロイ → 自分から Bot にメッセージを送る → Vercel の Functions ログ、または webhook のイベント `source.userId` を確認して控える
+- もしくは LINE Developers の Webhook イベントログ / 既存 bot のログから確認
+- 判明したら正しい userId を `LINE_ALLOWED_USER_ID` に設定（カンマ区切りで複数可）
+
+### 3. Vercel に環境変数を設定
+Vercel プロジェクト → Settings → Environment Variables に3つ追加（Production）:
+
+| 変数 | 値 |
+|---|---|
+| `LINE_CHANNEL_SECRET` | チャネルシークレット |
+| `LINE_CHANNEL_ACCESS_TOKEN` | チャネルアクセストークン |
+| `LINE_ALLOWED_USER_ID` | 自分の userId（`Uxxxx…`） |
+
+設定後、再デプロイ（環境変数反映のため）。
+
+### 4. Webhook URL を登録
+LINE Developers → Messaging API → **Webhook URL** に以下を設定し「検証（Verify）」で 200 を確認:
+
+```
+https://iwabuchi-makoto.com/api/line/webhook
+```
+
+「Webhook の利用」を ON にする。
+
+### 5. 動作確認
+自分の LINE から Bot にテキストを送る → Timeline に投稿され、「✅ 投稿しました」の Flex が返れば成功。反映は ISR のため `/` と `/timeline` を再検証済み（数秒で反映）。
+
+---
+
+## 仕様・挙動メモ
+
+- **セキュリティ**: `x-line-signature`（HMAC-SHA256）で真正性を検証し、さらに送信者 userId をホワイトリストで限定。両方を満たさないリクエストは投稿されない（署名不一致は 401、ホワイトリスト外は拒否メッセージを返信）。
+- **投稿内容**: メッセージ本文をそのまま Timeline の本文（richText）に。改行は段落として保持。投稿タイプは既定で「日記(diary)」。
+- **確認メッセージ**: 本文プレビュー＋「タイムラインを見る」ボタン付きの Flex を必ず返信。
+- **現時点の制限（今後の拡張候補）**:
+  - **テキストのみ対応**。画像投稿は未対応（LINE の画像を取得 → media にアップロード → 添付、という追加実装が必要）。
+  - 投稿タイプの指定なし（常に diary）。先頭に `#tech` 等のコマンドで切り替える拡張が可能。
+- **環境変数が未設定の場合**: webhook は 500 を返し投稿しない（安全側）。
+
+## 関連
+
+- 実装: `src/app/api/line/webhook/route.ts` / `src/lib/line.ts`
+- Timeline コレクション: `src/collections/TimelinePosts.ts`
+- Issue: #35

--- a/src/app/api/line/webhook/route.ts
+++ b/src/app/api/line/webhook/route.ts
@@ -1,0 +1,134 @@
+// src/app/api/line/webhook/route.ts
+// LINE Messaging API webhook（Issue #35）
+// 許可ユーザーが 1:1 トークで送ったテキストを Timeline に投稿し、確認をリッチメッセージで返信する。
+// セキュリティ:
+//   1) x-line-signature（HMAC-SHA256）でリクエストの真正性を検証
+//   2) source.type=user（1:1トーク）に限定し、送信者 userId を LINE_ALLOWED_USER_ID のホワイトリストに限定
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayloadClient } from '@/lib/payloadClient'
+import type { Timeline } from '@/payload-types'
+import {
+  verifyLineSignature,
+  isAllowedUser,
+  textToLexical,
+  buildConfirmFlex,
+  buildTextMessage,
+  replyLine,
+} from '@/lib/line'
+
+export const runtime = 'nodejs' // node:crypto / payload を使うため edge 不可
+export const dynamic = 'force-dynamic'
+
+type LineEvent = {
+  type?: string
+  replyToken?: string
+  webhookEventId?: string
+  deliveryContext?: { isRedelivery?: boolean }
+  source?: { type?: string; userId?: string }
+  message?: { type?: string; text?: string }
+}
+
+export async function POST(req: NextRequest) {
+  const channelSecret = process.env.LINE_CHANNEL_SECRET
+  const accessToken = process.env.LINE_CHANNEL_ACCESS_TOKEN
+  const allowList = process.env.LINE_ALLOWED_USER_ID
+
+  if (!channelSecret || !accessToken) {
+    console.error('LINE webhook: LINE_CHANNEL_SECRET / LINE_CHANNEL_ACCESS_TOKEN が未設定です')
+    return NextResponse.json({ ok: false }, { status: 500 })
+  }
+  if (!allowList) {
+    console.warn('LINE webhook: LINE_ALLOWED_USER_ID が未設定のため、すべての投稿を拒否します')
+  }
+
+  // 署名検証には生ボディが必要（パース前に取得）
+  const raw = await req.text()
+  const signature = req.headers.get('x-line-signature')
+  if (!verifyLineSignature(raw, signature, channelSecret)) {
+    return NextResponse.json({ ok: false, error: 'invalid signature' }, { status: 401 })
+  }
+
+  let body: { events?: LineEvent[] }
+  try {
+    body = JSON.parse(raw)
+  } catch {
+    return NextResponse.json({ ok: true }) // 空/検証リクエスト等は 200 で受ける
+  }
+  const events = Array.isArray(body.events) ? body.events : []
+
+  for (const event of events) {
+    const replyToken = event.replyToken
+    let created = false
+    try {
+      // 再送イベントは投稿しない（初回で成功済みの可能性が高く、二重投稿を防ぐ）
+      if (event.deliveryContext?.isRedelivery) continue
+      // テキストメッセージ以外は無視（画像等は今後対応）
+      if (event.type !== 'message' || event.message?.type !== 'text') continue
+      // グループ/ルームの発言を公開しないよう 1:1 トークのみ受け付ける
+      if (event.source?.type !== 'user') continue
+
+      // ホワイトリスト外からは投稿させない
+      if (!isAllowedUser(event.source?.userId, allowList)) {
+        if (replyToken) {
+          await replyLine(
+            replyToken,
+            [buildTextMessage('この LINE アカウントからは投稿できません。')],
+            accessToken,
+          )
+        }
+        continue
+      }
+
+      const text = String(event.message.text ?? '').trim()
+      if (!text) {
+        if (replyToken) {
+          await replyLine(
+            replyToken,
+            [buildTextMessage('本文が空です。テキストを送ってください。')],
+            accessToken,
+          )
+        }
+        continue
+      }
+
+      // Timeline へ投稿（LINE 経由の作成を許可するため overrideAccess）。
+      // '/' と '/timeline' の ISR 再検証は TimelinePosts の afterChange フックが担う。
+      const payload = await getPayloadClient()
+      await payload.create({
+        collection: 'timeline',
+        data: {
+          text: textToLexical(text) as Timeline['text'],
+          postType: 'diary',
+          publishedAt: new Date().toISOString(),
+        },
+        overrideAccess: true,
+      })
+      created = true
+
+      if (replyToken) {
+        await replyLine(replyToken, [buildConfirmFlex(text)], accessToken)
+      }
+    } catch (err) {
+      console.error('LINE webhook event error:', err)
+      if (replyToken) {
+        // 投稿自体は成功して後続（確認送信等）で失敗したケースを取り違えない
+        const message = created
+          ? '投稿は完了しましたが、確認メッセージの送信に失敗しました。'
+          : '投稿に失敗しました。時間をおいて再度お試しください。'
+        try {
+          await replyLine(replyToken, [buildTextMessage(message)], accessToken)
+        } catch {
+          // リプライ失敗は握りつぶす（webhook 応答は 200 を維持）
+        }
+      }
+    }
+  }
+
+  // LINE には常に 200 を返す（非 200 だと再送ループになるため）
+  return NextResponse.json({ ok: true })
+}
+
+// ヘルスチェック用（LINE コンソールの Verify は署名付き POST で来るため必須ではない）
+export async function GET() {
+  return NextResponse.json({ ok: true })
+}

--- a/src/lib/line.ts
+++ b/src/lib/line.ts
@@ -1,0 +1,131 @@
+// src/lib/line.ts
+// LINE Messaging API 連携ヘルパー（Issue #35: LINE から Timeline へ投稿）。
+// - 署名検証（x-line-signature / HMAC-SHA256）
+// - 送信者 userId のホワイトリスト判定
+// - プレーンテキスト → Payload Lexical editorState 変換
+// - 投稿確認用の Flex（リッチ）メッセージ生成 / リプライ送信
+import crypto from 'crypto'
+
+const LINE_REPLY_ENDPOINT = 'https://api.line.me/v2/bot/message/reply'
+
+// サイト URL は payload.config と同じ導出（末尾スラッシュ除去）
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  (process.env.NODE_ENV === 'production' ? 'https://iwabuchi-makoto.com' : 'http://localhost:3000')
+).replace(/\/$/, '')
+
+/**
+ * x-line-signature を検証する。生のリクエストボディに対する
+ * HMAC-SHA256（base64）を channelSecret で計算し、timing-safe に比較する。
+ */
+export function verifyLineSignature(
+  rawBody: string,
+  signature: string | null,
+  channelSecret: string,
+): boolean {
+  if (!signature) return false
+  const expected = crypto.createHmac('sha256', channelSecret).update(rawBody).digest('base64')
+  const a = Buffer.from(expected)
+  const b = Buffer.from(signature)
+  if (a.length !== b.length) return false
+  return crypto.timingSafeEqual(a, b)
+}
+
+/** 許可ユーザー判定（LINE_ALLOWED_USER_ID はカンマ区切りで複数可） */
+export function isAllowedUser(userId: string | undefined, allowList: string | undefined): boolean {
+  if (!userId || !allowList) return false
+  return allowList
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .includes(userId)
+}
+
+/**
+ * プレーンテキストを Payload（lexical）の richText editorState に変換する。
+ * 改行ごとに段落を分け、空行は空の段落として保持する。
+ */
+export function textToLexical(text: string) {
+  const paragraphs = text.split('\n').map((line) => ({
+    type: 'paragraph',
+    format: '',
+    indent: 0,
+    version: 1,
+    direction: 'ltr',
+    textStyle: '',
+    textFormat: 0,
+    children: line
+      ? [{ type: 'text', text: line, format: 0, style: '', mode: 'normal', detail: 0, version: 1 }]
+      : [],
+  }))
+  return {
+    root: {
+      type: 'root',
+      format: '',
+      indent: 0,
+      version: 1,
+      direction: 'ltr',
+      children: paragraphs,
+    },
+  }
+}
+
+/** 投稿確認用の Flex（リッチ）メッセージ。本文プレビューとタイムラインへの導線を持つ。 */
+export function buildConfirmFlex(preview: string) {
+  // 絵文字（サロゲートペア）を分断しないよう code point 単位で切り詰める
+  const chars = Array.from(preview)
+  const trimmed = chars.length > 80 ? `${chars.slice(0, 80).join('')}…` : preview
+  return {
+    type: 'flex',
+    altText: '✅ タイムラインに投稿しました',
+    contents: {
+      type: 'bubble',
+      body: {
+        type: 'box',
+        layout: 'vertical',
+        spacing: 'md',
+        contents: [
+          { type: 'text', text: '✅ 投稿しました', weight: 'bold', size: 'lg', color: '#1f2937' },
+          { type: 'text', text: trimmed, wrap: true, size: 'sm', color: '#4b5563' },
+        ],
+      },
+      footer: {
+        type: 'box',
+        layout: 'vertical',
+        contents: [
+          {
+            type: 'button',
+            style: 'primary',
+            color: '#5b52a0',
+            action: { type: 'uri', label: 'タイムラインを見る', uri: `${SITE_URL}/timeline` },
+          },
+        ],
+      },
+    },
+  }
+}
+
+/** プレーンテキストメッセージ（エラー・権限拒否の通知に使用） */
+export function buildTextMessage(text: string) {
+  return { type: 'text', text }
+}
+
+/** LINE Reply API でメッセージを返信する。 */
+export async function replyLine(
+  replyToken: string,
+  messages: unknown[],
+  accessToken: string,
+): Promise<boolean> {
+  const res = await fetch(LINE_REPLY_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ replyToken, messages }),
+  })
+  if (!res.ok) {
+    console.error('LINE reply failed:', res.status, await res.text().catch(() => ''))
+  }
+  return res.ok
+}

--- a/src/lib/urlMetadata.ts
+++ b/src/lib/urlMetadata.ts
@@ -12,8 +12,11 @@ export async function fetchUrlMetadata(url: string): Promise<UrlMetadata | null>
       headers: {
         'User-Agent': 'Mozilla/5.0 (compatible; Timeline Bot/1.0)',
       },
+      // 遅い相手先で呼び出し全体（beforeChange 経由の投稿処理含む）がハングしないよう上限を設ける。
+      // タイムアウト時は下の catch が null を返し、メタデータなしで投稿自体は成立する。
+      signal: AbortSignal.timeout(5000),
     })
-    
+
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`)
     }


### PR DESCRIPTION
## 概要
Issue #35 の実装。Payload 管理画面を開かずとも、**LINE のトークにテキストを送るだけで Timeline に投稿**でき、投稿確認をリッチメッセージ（Flex）で返す webhook を追加。

## 実装
- **`POST /api/line/webhook`**（`src/app/api/line/webhook/route.ts`）
  - `x-line-signature`（HMAC-SHA256）で真正性を検証（不一致は 401）
  - `source.type=user`（1:1トーク限定）＋ `userId` を `LINE_ALLOWED_USER_ID` に限定
  - 本文を `payload.create`（`overrideAccess`）で Timeline へ（postType=diary）
  - 確認 Flex を返信（本文プレビュー＋「タイムラインを見る」導線）
- **`src/lib/line.ts`**: 署名検証 / 許可判定 / text→Lexical 変換 / Flex 生成 / reply 送信
- **堅牢性**: 再送(`isRedelivery`)ガードで二重投稿防止、エラー時も 200 応答、`urlMetadata` の外部 fetch に 5s タイムアウト
- **ドキュメント**: `.env.example` に `LINE_*` を追記、`docs/LINE_TIMELINE_SETUP.md` にセットアップ手順

## レビュー / 検証
- **Fable 5 レビュー**実施 → Blocking なし。Should-fix（グループ遮断 / 再送ガード / fetch タイムアウト）と Nit（確認文言・サロゲート分断・型付け等）を反映
- `pnpm lint` / `pnpm build` 通過（`/api/line/webhook` ルート登録を確認）

## ⚠️ 稼働に必要なユーザー操作（`docs/LINE_TIMELINE_SETUP.md` 参照）
1. LINE Messaging API チャネルの用意（channel secret / access token）
2. 自分の LINE userId を確認
3. Vercel に `LINE_CHANNEL_SECRET` / `LINE_CHANNEL_ACCESS_TOKEN` / `LINE_ALLOWED_USER_ID` を設定
4. Webhook URL に `https://iwabuchi-makoto.com/api/line/webhook` を登録

## メモ
- v1 は**テキスト投稿のみ**（画像は今後対応）。
- 別件（範囲外）: `.env.example` の `PAYLOAD_SECRET` が実値に見えるため、実シークレットならローテーション推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)