### PR TITLE
fix(security): セキュリティ・プライバシーレビューに基づく修正（PAYLOAD_SECRET除去 / 問い合わせAPI強化）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,15 @@
 # Added by Payload
-PAYLOAD_SECRET=94759eda146d44e878b4b486
+# 秘密鍵は `openssl rand -hex 32` 等で生成した値を .env に設定する（実値をコミットしない）
+PAYLOAD_SECRET=<generate-a-random-secret>
 POSTGRES_URL=postgres://postgres:<password>@127.0.0.1:5432/
+
+# お問い合わせ（Letter）通知メール
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+# 通知の宛先（未設定時は SMTP_USER 宛）
+CONTACT_NOTIFY_TO=
 
 # LINE から Timeline へ投稿する webhook 用（Issue #35）
 # LINE Developers コンソールの Messaging API チャネルから取得

--- a/src/app/(frontend)/(site)/letter/page.tsx
+++ b/src/app/(frontend)/(site)/letter/page.tsx
@@ -45,11 +45,11 @@ export default function LetterPage() {
           <form onSubmit={handleSubmit} className="mform">
             <label>
               お名前
-              <input name="name" type="text" placeholder="name" required />
+              <input name="name" type="text" placeholder="name" maxLength={100} required />
             </label>
             <label>
               メッセージ
-              <textarea name="message" placeholder="message" rows={5} required />
+              <textarea name="message" placeholder="message" rows={5} maxLength={5000} required />
             </label>
             <button type="submit" className="submit" disabled={loading}>
               {loading ? '$ sending...' : '$ send --letter'}

--- a/src/app/api/letter/route.ts
+++ b/src/app/api/letter/route.ts
@@ -1,26 +1,75 @@
+// src/app/api/letter/route.ts
+// お問い合わせフォームAPI（公開エンドポイントだが以下の保護を実装）
+// - 入力のバリデーション（型・文字数上限）
+// - IPベースの簡易レート制限（サーバーレスのためベストエフォート）
+// - Payload local API 経由で作成し、Letters コレクションの通知メールフックを発火させる
 import { NextRequest, NextResponse } from 'next/server'
-import { Pool } from 'pg'
+import { getPayloadClient } from '@/lib/payloadClient'
 
-const pool = new Pool({
-  connectionString: process.env.POSTGRES_URL,
-  ssl: false,
-})
+const NAME_MAX = 100
+const MESSAGE_MAX = 5000
+const RATE_LIMIT_WINDOW_MS = 60_000
+const RATE_LIMIT_MAX = 5 // 1分あたり5回/IPまで
+
+// インスタンス生存中のみ有効な簡易レートリミッタ
+const rateMap = new Map<string, { count: number; resetAt: number }>()
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now()
+  const entry = rateMap.get(ip)
+  if (!entry || now > entry.resetAt) {
+    rateMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS })
+    return false
+  }
+  entry.count += 1
+  return entry.count > RATE_LIMIT_MAX
+}
 
 export async function POST(req: NextRequest) {
-  const { name, message } = await req.json()
+  // x-real-ip はプラットフォーム（Vercel）が設定する信頼できる値を優先し、
+  // クライアントが偽装しうる x-forwarded-for は最後のフォールバックにする
+  const ip =
+    req.headers.get('x-real-ip')?.trim() ||
+    req.headers.get('x-vercel-forwarded-for')?.split(',')[0]?.trim() ||
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  if (isRateLimited(ip)) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 })
+  }
 
-  if (!name || !message) {
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const { name, message } = (body ?? {}) as { name?: unknown; message?: unknown }
+  if (typeof name !== 'string' || typeof message !== 'string') {
     return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
   }
 
+  const trimmedName = name.trim()
+  const trimmedMessage = message.trim()
+  if (!trimmedName || !trimmedMessage) {
+    return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
+  }
+  if (trimmedName.length > NAME_MAX || trimmedMessage.length > MESSAGE_MAX) {
+    return NextResponse.json({ error: 'Input too long' }, { status: 400 })
+  }
+
   try {
-    await pool.query('INSERT INTO letter (name, message) VALUES ($1, $2)', [
-      name,
-      message,
-    ])
+    const payload = await getPayloadClient()
+    await payload.create({
+      collection: 'letter',
+      data: {
+        name: trimmedName,
+        message: trimmedMessage,
+      },
+    })
     return NextResponse.json({ ok: true })
   } catch (err) {
-    console.error(err)
-    return NextResponse.json({ error: 'Database error' }, { status: 500 })
+    console.error('Letter create error:', err)
+    return NextResponse.json({ error: 'Failed to save' }, { status: 500 })
   }
 }

--- a/src/app/api/letter/route.ts
+++ b/src/app/api/letter/route.ts
@@ -16,8 +16,12 @@ const rateMap = new Map<string, { count: number; resetAt: number }>()
 
 function isRateLimited(ip: string): boolean {
   const now = Date.now()
+  // 期限切れエントリを掃除してユニークIP数ぶんのメモリ単調増加を防ぐ
+  for (const [key, value] of rateMap) {
+    if (now > value.resetAt) rateMap.delete(key)
+  }
   const entry = rateMap.get(ip)
-  if (!entry || now > entry.resetAt) {
+  if (!entry) {
     rateMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS })
     return false
   }
@@ -28,6 +32,7 @@ function isRateLimited(ip: string): boolean {
 export async function POST(req: NextRequest) {
   // x-real-ip はプラットフォーム（Vercel）が設定する信頼できる値を優先し、
   // クライアントが偽装しうる x-forwarded-for は最後のフォールバックにする
+  // （Vercel 以外へ移設する場合は信頼できる proxy ヘッダーを見直すこと）
   const ip =
     req.headers.get('x-real-ip')?.trim() ||
     req.headers.get('x-vercel-forwarded-for')?.split(',')[0]?.trim() ||

--- a/src/collections/Letters.ts
+++ b/src/collections/Letters.ts
@@ -68,8 +68,9 @@ ${message}`,
     ],
   },
   fields: [
-    { name: 'name', label: 'お名前', type: 'text', required: true },
-    { name: 'message', label: 'メッセージ', type: 'textarea', required: true },
+    // 文字数上限は /api/letter だけでなくコレクション側でも強制する（多層防御）
+    { name: 'name', label: 'お名前', type: 'text', required: true, maxLength: 100 },
+    { name: 'message', label: 'メッセージ', type: 'textarea', required: true, maxLength: 5000 },
     {
       name: 'createdAt',
       label: '送信日時',

--- a/src/collections/Letters.ts
+++ b/src/collections/Letters.ts
@@ -5,7 +5,9 @@ import { anyone, adminOnly } from '@/lib/access'
 
 // SMTP 各段階のタイムアウトはサーバーレス関数のデッドラインより十分短くする
 // （Nodemailer 既定は分単位で、応答しないSMTPサーバーに掴まると
-//   リクエスト全体がタイムアウトし、利用者の再送 → 重複投稿につながる）
+//   リクエスト全体がタイムアウトし、利用者の再送 → 重複投稿につながる）。
+// 期限超過時は Nodemailer 自身が下層ソケットを閉じてエラーを返すため、
+// 外側で Promise.race 等により打ち切ると接続だけが放置される。行わないこと。
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST!,
   port: Number(process.env.SMTP_PORT!),
@@ -18,9 +20,6 @@ const transporter = nodemailer.createTransport({
   greetingTimeout: 5_000,
   socketTimeout: 8_000,
 })
-
-// 送信全体の上限。超過しても投稿の保存は成功扱いにする
-const MAIL_TIMEOUT_MS = 8_000
 
 // 利用者入力を通知メールのHTMLへ埋め込む前にエスケープする
 const escapeHtml = (value: string): string =>
@@ -53,12 +52,8 @@ const Letter: CollectionConfig = {
             return doc
           }
 
-          let timer: ReturnType<typeof setTimeout> | undefined
           try {
-            const timeout = new Promise<never>((_, reject) => {
-              timer = setTimeout(() => reject(new Error('mail send timeout')), MAIL_TIMEOUT_MS)
-            })
-            const send = transporter.sendMail({
+            await transporter.sendMail({
               from: `"お問い合わせ通知" <${process.env.SMTP_USER!}>`,
               to,
               subject: '新しいお問い合わせが届きました',
@@ -71,15 +66,9 @@ ${message}`,
                 <p><strong>メッセージ:</strong><br/>${escapeHtml(String(message)).replace(/\n/g, '<br/>')}</p>
               `,
             })
-            // 送信が MAIL_TIMEOUT_MS 内に完了しなければ打ち切り、保存は成功のまま返す
-            await Promise.race([send, timeout])
-            // race で打ち切った場合も裏で走り続ける send の未処理拒否を防ぐ
-            send.catch(() => {})
           } catch (err) {
             // 通知メールの失敗で投稿の保存自体を失敗させない
             console.error('Letter 通知メールの送信に失敗しました:', err)
-          } finally {
-            if (timer) clearTimeout(timer)
           }
         }
         return doc

--- a/src/collections/Letters.ts
+++ b/src/collections/Letters.ts
@@ -3,6 +3,9 @@ import { CollectionConfig } from 'payload'
 import nodemailer from 'nodemailer'
 import { anyone, adminOnly } from '@/lib/access'
 
+// SMTP 各段階のタイムアウトはサーバーレス関数のデッドラインより十分短くする
+// （Nodemailer 既定は分単位で、応答しないSMTPサーバーに掴まると
+//   リクエスト全体がタイムアウトし、利用者の再送 → 重複投稿につながる）
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST!,
   port: Number(process.env.SMTP_PORT!),
@@ -11,7 +14,13 @@ const transporter = nodemailer.createTransport({
     user: process.env.SMTP_USER!,
     pass: process.env.SMTP_PASS!,
   },
+  connectionTimeout: 5_000,
+  greetingTimeout: 5_000,
+  socketTimeout: 8_000,
 })
+
+// 送信全体の上限。超過しても投稿の保存は成功扱いにする
+const MAIL_TIMEOUT_MS = 8_000
 
 // 利用者入力を通知メールのHTMLへ埋め込む前にエスケープする
 const escapeHtml = (value: string): string =>
@@ -44,8 +53,12 @@ const Letter: CollectionConfig = {
             return doc
           }
 
+          let timer: ReturnType<typeof setTimeout> | undefined
           try {
-            await transporter.sendMail({
+            const timeout = new Promise<never>((_, reject) => {
+              timer = setTimeout(() => reject(new Error('mail send timeout')), MAIL_TIMEOUT_MS)
+            })
+            const send = transporter.sendMail({
               from: `"お問い合わせ通知" <${process.env.SMTP_USER!}>`,
               to,
               subject: '新しいお問い合わせが届きました',
@@ -58,9 +71,15 @@ ${message}`,
                 <p><strong>メッセージ:</strong><br/>${escapeHtml(String(message)).replace(/\n/g, '<br/>')}</p>
               `,
             })
+            // 送信が MAIL_TIMEOUT_MS 内に完了しなければ打ち切り、保存は成功のまま返す
+            await Promise.race([send, timeout])
+            // race で打ち切った場合も裏で走り続ける send の未処理拒否を防ぐ
+            send.catch(() => {})
           } catch (err) {
             // 通知メールの失敗で投稿の保存自体を失敗させない
             console.error('Letter 通知メールの送信に失敗しました:', err)
+          } finally {
+            if (timer) clearTimeout(timer)
           }
         }
         return doc

--- a/src/collections/Letters.ts
+++ b/src/collections/Letters.ts
@@ -13,6 +13,15 @@ const transporter = nodemailer.createTransport({
   },
 })
 
+// 利用者入力を通知メールのHTMLへ埋め込む前にエスケープする
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
 const Letter: CollectionConfig = {
   slug: 'letter',
   labels: { singular: 'Letter', plural: 'Letters' },
@@ -26,23 +35,33 @@ const Letter: CollectionConfig = {
     afterChange: [
       async ({ doc, operation }) => {
         if (operation === 'create') {
-          const { name, email, message } = doc
+          const { name, message } = doc
+          // 通知先は環境変数から取得（アドレスをソースにハードコードしない）
+          const to = process.env.CONTACT_NOTIFY_TO || process.env.SMTP_USER
 
-          await transporter.sendMail({
-            from: `"お問い合わせ通知" <${process.env.SMTP_USER!}>`,
-            to: 'makoto01401@gmail.com', // ← ここを固定アドレスに変更
-            subject: '新しいお問い合わせが届きました',
-            text: `
+          if (!to) {
+            console.error('Letter 通知: CONTACT_NOTIFY_TO / SMTP_USER が未設定のため送信をスキップします')
+            return doc
+          }
+
+          try {
+            await transporter.sendMail({
+              from: `"お問い合わせ通知" <${process.env.SMTP_USER!}>`,
+              to,
+              subject: '新しいお問い合わせが届きました',
+              text: `
 お名前: ${name}
-メール: ${email || '（未登録）'}
 メッセージ:
 ${message}`,
-            html: `
-              <p><strong>お名前:</strong> ${name}</p>
-              <p><strong>メール:</strong> ${email || '（未登録）'}</p>
-              <p><strong>メッセージ:</strong><br/>${message.replace(/\n/g, '<br/>')}</p>
-            `,
-          })
+              html: `
+                <p><strong>お名前:</strong> ${escapeHtml(String(name))}</p>
+                <p><strong>メッセージ:</strong><br/>${escapeHtml(String(message)).replace(/\n/g, '<br/>')}</p>
+              `,
+            })
+          } catch (err) {
+            // 通知メールの失敗で投稿の保存自体を失敗させない
+            console.error('Letter 通知メールの送信に失敗しました:', err)
+          }
         }
         return doc
       },


### PR DESCRIPTION
# セキュリティ・プライバシーレビューに基づく修正

## 概要

公開リポジトリであることを前提に、コードベース全体をセキュリティ・プライバシー観点でレビューし、以下を修正しました。コレクションのアクセス制御・LINE webhook の署名検証・いいねAPIの保護・CORS/CSRF 設定は適切で問題ありませんでした。掲載中の個人情報（実名・職種・SNS・プロフィール写真）はポートフォリオとして標準的な範囲で、生年月日・住所等の過剰な情報はありません。

## ⚠️ マージ後に必要な運用対応（重要）

1. **Vercel の `PAYLOAD_SECRET` を新しい値にローテーションする**
   旧値は公開リポジトリの git 履歴に残っているため、リポジトリ側の修正だけでは対策になりません。`openssl rand -hex 32` 等で新しい値を生成して Vercel の環境変数を差し替え、再デプロイしてください（既存の管理画面ログインセッションが無効になるだけで、データへの影響はありません）。
2. **Vercel に `CONTACT_NOTIFY_TO` を追加する（任意）**
   問い合わせ通知の宛先です。未設定の場合は `SMTP_USER` 宛に送信されます。

## 変更内容

### `.env.example`
- コミットされていた `PAYLOAD_SECRET` の実値をプレースホルダに置換
- SMTP / `CONTACT_NOTIFY_TO` の項目を追記

### `src/collections/Letters.ts`
- 通知先メールアドレスのハードコード（個人 Gmail）を環境変数 `CONTACT_NOTIFY_TO`（未設定時は `SMTP_USER`）に移行 — 公開リポジトリでのアドレス収集リスクを解消
- 通知メール HTML へのユーザー入力埋め込みをエスケープ（HTML インジェクション対策）
- 存在しない `email` フィールドへの参照を除去
- メール送信失敗時も問い合わせの保存自体は成功するよう try/catch を追加
- `name`（100字）/ `message`（5000字）の `maxLength` をコレクション側でも強制（多層防御）

### `src/app/api/letter/route.ts`
- 生 `pg`（`ssl: false`）での直 INSERT を Payload local API 経由に書き換え
  - 通知メールフックが発火するようになる（従来はフックが発火せず通知が飛んでいなかった）
  - `ssl: false` での DB 接続を解消
- IP ベースのレート制限（5回/分、いいねAPIと同方式）を追加
- 型バリデーションと文字数上限（name 100字 / message 5000字）を追加

### `src/app/(frontend)/(site)/letter/page.tsx`
- 入力欄に `maxLength` を付与し、上限超過を入力段階で防止

## テスト項目

- [x] `pnpm exec tsc --noEmit` パス
- [x] `pnpm lint` エラーなし（既存のマイグレーション警告のみ）
- [x] Fable サブエージェントによるコードレビュー実施 → Should-fix / Nit を全て反映
- [ ] Vercel ビルド（CI）
- [ ] デプロイ後、問い合わせフォーム送信で通知メールが届くことを確認

## レビューポイント

1. `/api/letter` は Next.js の静的ルートとして Payload の REST catch-all（`(payload)/api/[...slug]`）より優先されるため、フォームの向き先は変わりません
2. フロントとの契約（`{name, message}` POST → `res.ok` 判定）は維持しており、フォームの挙動は互換です
3. 通知メールが「飛ぶようになる」のは意図した挙動変化です

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLPBRYWHcqKRzmm6GANVug

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLPBRYWHcqKRzmm6GANVug)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * お問い合わせ内容の保存後、設定した宛先へ通知メールを送信できるようになりました。
  * 通知メールの内容が安全に処理されるようになりました。
* **バグ修正**
  * お問い合わせフォームに入力文字数の上限を追加しました。
  * 不正な入力や空の内容を適切に処理します。
  * 短時間の大量送信を抑制し、保存処理の安定性を向上しました。
  * メール送信のタイムアウトやエラー発生時も、お問い合わせの保存を継続できるよう改善しました。
* **設定**
  * 秘密鍵を安全に設定できる形式へ変更しました。
  * SMTP通知メール用の設定項目を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->