### PR TITLE
fix(gallery): 画像プレビューモーダルが画面からズレる問題を修正

### DIFF
--- a/src/app/(frontend)/mist.css
+++ b/src/app/(frontend)/mist.css
@@ -764,8 +764,10 @@
   width: auto;
   height: auto;
   max-width: 92vw;
-  max-height: 80vh;
-  max-height: 80dvh; /* SP で画像+閉じるボタンが可視領域に収まるように */
+  /* 60px = SP で画像下に積まれる閉じるボタン 44px + margin-top 16px。
+     縦の短い画面でもボタンごと .imgmodal(90dvh) 内に収まるよう差し引く */
+  max-height: min(80vh, calc(90vh - 60px));
+  max-height: min(80dvh, calc(90dvh - 60px));
   object-fit: contain;
   border: 1px solid var(--m-hairline);
   background: var(--m-surface);

--- a/src/app/(frontend)/mist.css
+++ b/src/app/(frontend)/mist.css
@@ -739,11 +739,15 @@
 /* ── 画像プレビューモーダル（ネイティブ <dialog>） ─────────────
    Escape・フォーカストラップ・フォーカス復帰はブラウザ標準に委ねる */
 .mist .imgmodal {
+  /* Tailwind v4 preflight の `* { margin: 0 }` が UA の dialog { margin: auto }
+     （<dialog> センタリングの根拠）を打ち消すため、明示的に復元する */
+  margin: auto;
   padding: 0;
   border: 0;
   background: transparent;
   max-width: 92vw;
   max-height: 90vh;
+  max-height: 90dvh; /* SP のURLバー表示中も可視領域基準に（非対応環境は上の vh にフォールバック） */
   overflow: visible;
 }
 .mist .imgmodal::backdrop {
@@ -761,6 +765,7 @@
   height: auto;
   max-width: 92vw;
   max-height: 80vh;
+  max-height: 80dvh; /* SP で画像+閉じるボタンが可視領域に収まるように */
   object-fit: contain;
   border: 1px solid var(--m-hairline);
   background: var(--m-surface);


### PR DESCRIPTION
## 問題

モバイルで画像プレビュー（ギャラリー等の `ImageModal`）を開くと、モーダルが画面中央ではなく**ビューポート左上に張り付く**。報告はモバイルだが PC も同様に左上固定（画像が大きく目立ちにくいだけ）。

## 原因

PR #56 でプレビューをネイティブ `<dialog>` + `showModal()` に移行したが、Tailwind v4 preflight の

```css
*, ::after, ::before, ::backdrop, ::file-selector-button { margin: 0; padding: 0; ... }
```

が UA スタイルシートの `dialog { margin: auto }`（ネイティブ dialog がセンタリングされる根拠）を打ち消すため、`inset: 0` + `margin: 0` の解決で左上に配置されていた（Tailwind v4 + native dialog の既知の組み合わせ問題）。

## 修正

`mist.css` の `.mist .imgmodal` に `margin: auto` を明示してセンタリングを復元。あわせて `max-height` を `dvh` 併記（vh フォールバック付き）にし、SP の URL バー表示中も画像+閉じるボタンが可視領域に収まるようにした。

## 検証

- preflight 相当 + `mist.css` 転記の静的再現ページを Playwright で確認（このサーバーは `.env` 無しのため実アプリでのデータ確認は不可）:
  - 390×844(SP): 修正前 dialog 位置 `(0, 0)` → 修正後 `(16, 257)`（中央）
  - 1280×800(PC): 修正前 `(0, 0)` → 修正後 `(214, 80)`（中央）
- `pnpm typecheck` / `pnpm lint` / `pnpm test`（23件）/ `next build --experimental-build-mode compile` すべて通過。フルビルドは Vercel CI に委ねる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * 画像プレビューモーダルが画面中央に正しく配置されるよう改善しました。
  * 画面サイズに応じて、モーダルと画像が適切に表示されるよう調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->