### PR TITLE
feat(gallery): 画像プレビューに読み込み待ちインジケーターを追加

### DIFF
--- a/src/app/(frontend)/mist.css
+++ b/src/app/(frontend)/mist.css
@@ -787,9 +787,9 @@
   transition: opacity 0.25s ease;
 }
 .mist .imgmodal-img.is-loaded { opacity: 1; }
-/* 読み込み中ピル（.spin = 既存ブライユ・スピナー）。表示を 150ms 遅らせ、
-   キャッシュ済み画像の即時描画時にはフラッシュしないようにする */
-.mist .imgmodal-loading {
+/* 状態ピル（読み込み中/エラー共通の器。.spin = 既存ブライユ・スピナー） */
+.mist .imgmodal-loading,
+.mist .imgmodal-error {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -800,6 +800,10 @@
   color: var(--m-sub);
   font-size: var(--fs-meta);
   white-space: nowrap;
+}
+/* 読み込み中のみ表示を 150ms 遅らせ、キャッシュ済み画像の即時描画時には
+   フラッシュしないようにする（エラーは遅延させず即時表示） */
+.mist .imgmodal-loading {
   animation: m-fadein 0.2s ease-out 0.15s both;
 }
 /* 閉じるボタン: SP は画像下に独立表示、PC はモーダル右上 */

--- a/src/app/(frontend)/mist.css
+++ b/src/app/(frontend)/mist.css
@@ -34,6 +34,11 @@
 @keyframes m-spin {
   to { transform: rotate(360deg); }
 }
+/* 移動を伴わない出現用（reduced-motion でも許容されるopacityのみのフェード） */
+@keyframes m-fadein {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
 /* ブライユ・スピナーのフレーム（JS の高頻度 setState を廃止し CSS で回す） */
 @keyframes m-braille {
   0% { content: '⠋'; }
@@ -760,6 +765,13 @@
   flex-direction: column;
   align-items: center;
 }
+/* 読み込み中は body 側で場所を確保する（未ロードの img は自然寸法を持たず
+   ほぼ 0px に潰れるため、img 基準ではピルを配置できない） */
+.mist .imgmodal-body.is-loading {
+  min-width: min(80vw, 520px);
+  min-height: min(48dvh, 420px);
+  justify-content: center;
+}
 .mist .imgmodal-img {
   width: auto;
   height: auto;
@@ -771,6 +783,24 @@
   object-fit: contain;
   border: 1px solid var(--m-hairline);
   background: var(--m-surface);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.mist .imgmodal-img.is-loaded { opacity: 1; }
+/* 読み込み中ピル（.spin = 既存ブライユ・スピナー）。表示を 150ms 遅らせ、
+   キャッシュ済み画像の即時描画時にはフラッシュしないようにする */
+.mist .imgmodal-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border: 1px solid var(--m-hairline);
+  border-radius: 999px;
+  background: var(--m-surface);
+  color: var(--m-sub);
+  font-size: var(--fs-meta);
+  white-space: nowrap;
+  animation: m-fadein 0.2s ease-out 0.15s both;
 }
 /* 閉じるボタン: SP は画像下に独立表示、PC はモーダル右上 */
 .mist .imgmodal-close {

--- a/src/components/gallery/ImageModal.tsx
+++ b/src/components/gallery/ImageModal.tsx
@@ -67,7 +67,10 @@ function ModalBody({ src, alt, onClose }: { src: string; alt: string; onClose: (
         sizes="92vw"
         className={`imgmodal-img${status === 'loaded' ? ' is-loaded' : ''}`}
         onLoad={() => setStatus('loaded')}
-        onError={() => setStatus('error')}
+        onError={() => {
+          console.error('ImageModal: 画像の読み込みに失敗しました', src)
+          setStatus('error')
+        }}
         // リッチテキスト経由で外部ホストの画像も開くため、CF/相対以外は最適化を通さない
         unoptimized={!isOptimizableSrc(toCFUrl(src))}
       />
@@ -78,7 +81,7 @@ function ModalBody({ src, alt, onClose }: { src: string; alt: string; onClose: (
         </span>
       )}
       {status === 'error' && (
-        <span className="imgmodal-loading" role="alert">
+        <span className="imgmodal-error" role="alert">
           画像を読み込めませんでした
         </span>
       )}

--- a/src/components/gallery/ImageModal.tsx
+++ b/src/components/gallery/ImageModal.tsx
@@ -16,12 +16,6 @@ interface ImageModalProps {
 
 export default function ImageModal({ src, alt = '', isOpen, onClose }: ImageModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
-  const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading')
-
-  // 開くたび・画像が変わるたびに読み込み状態へ戻す
-  useEffect(() => {
-    if (isOpen) setStatus('loading')
-  }, [isOpen, src])
 
   useEffect(() => {
     const dialog = dialogRef.current
@@ -52,41 +46,50 @@ export default function ImageModal({ src, alt = '', isOpen, onClose }: ImageModa
         if (e.target === e.currentTarget) onClose()
       }}
     >
-      {isOpen && src && (
-        <div className={`imgmodal-body${status !== 'loaded' ? ' is-loading' : ''}`}>
-          <Image
-            src={toCFUrl(src)}
-            alt={alt}
-            width={1200}
-            height={900}
-            sizes="92vw"
-            className={`imgmodal-img${status === 'loaded' ? ' is-loaded' : ''}`}
-            onLoad={() => setStatus('loaded')}
-            onError={() => setStatus('error')}
-            // リッチテキスト経由で外部ホストの画像も開くため、CF/相対以外は最適化を通さない
-            unoptimized={!isOptimizableSrc(toCFUrl(src))}
-          />
-          {status === 'loading' && (
-            <span className="imgmodal-loading" role="status">
-              <span className="spin" aria-hidden="true" />
-              読み込み中…
-            </span>
-          )}
-          {status === 'error' && (
-            <span className="imgmodal-loading" role="alert">
-              画像を読み込めませんでした
-            </span>
-          )}
-          <button
-            type="button"
-            className="imgmodal-close"
-            aria-label="プレビューを閉じる"
-            onClick={onClose}
-          >
-            ×
-          </button>
-        </div>
-      )}
+      {/* 読み込み状態は ModalBody 内に閉じる。開くたびにマウントし直される
+          （閉時にアンマウント + key=src）ため、初回レンダーから必ず loading で
+          始まり、前回の loaded/error が次の画像へ漏れない */}
+      {isOpen && src && <ModalBody key={src} src={src} alt={alt} onClose={onClose} />}
     </dialog>
+  )
+}
+
+function ModalBody({ src, alt, onClose }: { src: string; alt: string; onClose: () => void }) {
+  const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading')
+
+  return (
+    <div className={`imgmodal-body${status !== 'loaded' ? ' is-loading' : ''}`}>
+      <Image
+        src={toCFUrl(src)}
+        alt={alt}
+        width={1200}
+        height={900}
+        sizes="92vw"
+        className={`imgmodal-img${status === 'loaded' ? ' is-loaded' : ''}`}
+        onLoad={() => setStatus('loaded')}
+        onError={() => setStatus('error')}
+        // リッチテキスト経由で外部ホストの画像も開くため、CF/相対以外は最適化を通さない
+        unoptimized={!isOptimizableSrc(toCFUrl(src))}
+      />
+      {status === 'loading' && (
+        <span className="imgmodal-loading" role="status">
+          <span className="spin" aria-hidden="true" />
+          読み込み中…
+        </span>
+      )}
+      {status === 'error' && (
+        <span className="imgmodal-loading" role="alert">
+          画像を読み込めませんでした
+        </span>
+      )}
+      <button
+        type="button"
+        className="imgmodal-close"
+        aria-label="プレビューを閉じる"
+        onClick={onClose}
+      >
+        ×
+      </button>
+    </div>
   )
 }

--- a/src/components/gallery/ImageModal.tsx
+++ b/src/components/gallery/ImageModal.tsx
@@ -3,7 +3,7 @@
 // 画像プレビューモーダル。ネイティブ <dialog> + showModal() を採用し、
 // Escape で閉じる・フォーカストラップ・閉時の呼び出し元へのフォーカス復帰を
 // ブラウザ標準の挙動に委ねる（独自ポータル/z-index 管理は廃止）。
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
 import { toCFUrl, isOptimizableSrc } from '@/lib/cfUrl'
 
@@ -16,6 +16,12 @@ interface ImageModalProps {
 
 export default function ImageModal({ src, alt = '', isOpen, onClose }: ImageModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
+  const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading')
+
+  // 開くたび・画像が変わるたびに読み込み状態へ戻す
+  useEffect(() => {
+    if (isOpen) setStatus('loading')
+  }, [isOpen, src])
 
   useEffect(() => {
     const dialog = dialogRef.current
@@ -47,17 +53,30 @@ export default function ImageModal({ src, alt = '', isOpen, onClose }: ImageModa
       }}
     >
       {isOpen && src && (
-        <div className="imgmodal-body">
+        <div className={`imgmodal-body${status !== 'loaded' ? ' is-loading' : ''}`}>
           <Image
             src={toCFUrl(src)}
             alt={alt}
             width={1200}
             height={900}
             sizes="92vw"
-            className="imgmodal-img"
+            className={`imgmodal-img${status === 'loaded' ? ' is-loaded' : ''}`}
+            onLoad={() => setStatus('loaded')}
+            onError={() => setStatus('error')}
             // リッチテキスト経由で外部ホストの画像も開くため、CF/相対以外は最適化を通さない
             unoptimized={!isOptimizableSrc(toCFUrl(src))}
           />
+          {status === 'loading' && (
+            <span className="imgmodal-loading" role="status">
+              <span className="spin" aria-hidden="true" />
+              読み込み中…
+            </span>
+          )}
+          {status === 'error' && (
+            <span className="imgmodal-loading" role="alert">
+              画像を読み込めませんでした
+            </span>
+          )}
           <button
             type="button"
             className="imgmodal-close"


### PR DESCRIPTION
## 目的

画像プレビュー（`ImageModal`）を開いてから原本画像が表示されるまでの間、モーダルが空（閉じるボタンのみ）のままで、開くたびにユーザーのストレスになっていた。読み込み待ちを可視化する。

## 実装

Mist Terminal の既存資産を再利用し、新規の意匠は追加していない。

- **読み込み中**: 既存のブライユ・スピナー `.spin`（reduced-motion 時は `●` 静止にフォールバック済み）+「読み込み中…」のピル（`--m-surface` / `--m-hairline` / `--fs-meta` トークン準拠、4px系余白）をプレビュー領域中央に表示
- **アンチフラッシュ**: ピルの表示を CSS で 150ms 遅延（`m-fadein` = opacity のみの新規 keyframes）。キャッシュ済み画像が即描画されるケースではピルが一切見えない
- **領域確保**: 未ロードの `<img>`（`width:auto/height:auto`）は自然寸法を持たず約 0px に潰れるため、`.imgmodal-body.is-loading` 側で `min()` ベースの領域を確保
- **完了時**: 画像を opacity のみの 0.25s フェードインで表示
- **失敗時**: 「画像を読み込めませんでした」を `role=alert` で表示（無限スピナー防止）。読み込み中ピルは `role=status`

## 検証

- 実アプリはこのサーバーで起動不可（`.env` 無し）のため、mist.css 転記+preflight相当の再現ページを Playwright で確認:
  - 読み込み中(SP 390×844): ピルが領域中央 `(132, 376)` に表示、body が 312×405 を確保
  - 完了後: ピル除去・画像 359×270 が中央、エラー時: エラーピル表示
- `pnpm typecheck` / `pnpm lint` / `pnpm test` / `next build --experimental-build-mode compile` すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 画像モーダルに読み込み中の表示を追加しました。
  - 読み込み中はスピナーを表示し、画像領域を確保してレイアウトのずれを防ぎます。
  - 読み込み完了後は画像をフェードイン表示します。
  - 読み込みに失敗した場合はエラーメッセージを表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->