### PR TITLE
feat(images): 画像読み込み待ちをスマート化（ぼかしポスター/シマー/フェードイン）

### DIFF
--- a/src/app/(frontend)/mist.css
+++ b/src/app/(frontend)/mist.css
@@ -39,6 +39,11 @@
   from { opacity: 0; }
   to { opacity: 1; }
 }
+/* 画像プレースホルダーのシマー（低コントラスト。待ちが視認される面のみに使う） */
+@keyframes m-shimmer {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
+}
 /* ブライユ・スピナーのフレーム（JS の高頻度 setState を廃止し CSS で回す） */
 @keyframes m-braille {
   0% { content: '⠋'; }
@@ -642,6 +647,14 @@
   margin: 0;
   cursor: zoom-in;
   transition: filter 0.25s;
+  /* 読み込み中プレースホルダー（masonry と同じシマー） */
+  background: linear-gradient(105deg, oklch(0.93 0.01 262), oklch(0.89 0.02 262), oklch(0.93 0.01 262));
+  background-size: 300% 100%;
+  animation: m-shimmer 1.8s ease-in-out infinite;
+}
+.mist .photos .ph:has(img.is-loaded) {
+  animation: none;
+  background: oklch(0.92 0.015 262);
 }
 @media (hover: hover) {
   .mist .photos .ph:hover { filter: brightness(0.94); }
@@ -787,6 +800,48 @@
   transition: opacity 0.25s ease;
 }
 .mist .imgmodal-img.is-loaded { opacity: 1; }
+/* 読み込み完了フェードイン（SmartImage が is-loaded を付与。opacityのみ） */
+.mist .imgfade {
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+.mist .imgfade.is-loaded { opacity: 1; }
+
+/* ポスター段（グリッドで描画済みのキャッシュ画像を即時表示し、原本を上に重ねる） */
+.mist .imgmodal-stage {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+}
+.mist .imgmodal-poster {
+  opacity: 1; /* .imgmodal-img の「原本ロード待ち透明」を打ち消す（ポスターは即時表示） */
+  /* 低解像度ポスターを原本の表示サイズまで拡大する。max-height と競合した場合は
+     置換要素の制約解決により縦横比を保ったまま縮む（原本と同じ contain 寸法になる） */
+  width: 92vw;
+  filter: blur(10px) saturate(1.05);
+  transform: scale(1.03); /* ブラー端の白フチをはみ出しでクリップ */
+}
+.mist .imgmodal-full {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  object-fit: contain;
+  border: 0;
+  background: none;
+}
+/* ポスターがある場合、状態ピルは段の中央に重ねる（高さを足さない） */
+.mist .imgmodal-stage .imgmodal-loading,
+.mist .imgmodal-stage .imgmodal-error {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+}
+
 /* 状態ピル（読み込み中/エラー共通の器。.spin = 既存ブライユ・スピナー） */
 .mist .imgmodal-loading,
 .mist .imgmodal-error {
@@ -853,7 +908,8 @@
 /* ── Gallery コンポーネント（枠なし: 最近の静止画グリッド + 統合ストリーム） ── */
 /* minmax(140px): 中央が最小320pxのとき 2 列が成立し、先頭 .big(span 2) が溢れない */
 .mist .gal { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); grid-auto-rows: 1fr; gap: 8px; }
-.mist .gal .g { position: relative; display: block; aspect-ratio: 1; overflow: hidden; border: 0; transition: filter 0.25s; }
+/* 静的トーンのプレースホルダー（サーバー描画面・マーキーは常時アニメーションを避ける） */
+.mist .gal .g { position: relative; display: block; aspect-ratio: 1; overflow: hidden; border: 0; transition: filter 0.25s; background: oklch(0.92 0.015 262); }
 .mist .gal .g.big { grid-column: span 2; grid-row: span 2; }
 @media (hover: hover) {
   .mist .gal .g:hover { filter: brightness(0.94); }
@@ -886,7 +942,7 @@
 .mist .substream { display: flex; align-items: baseline; gap: 8px; margin: 16px 0 8px; font-size: var(--fs-meta); color: var(--m-sub); }
 .mist .streamwrap { position: relative; overflow: hidden; }
 .mist .streamrow { display: flex; gap: 8px; width: max-content; animation: m-marquee 34s linear infinite; }
-.mist .sph { position: relative; display: block; width: 180px; height: 120px; flex: none; overflow: hidden; border: 0; transition: filter 0.25s; }
+.mist .sph { position: relative; display: block; width: 180px; height: 120px; flex: none; overflow: hidden; border: 0; transition: filter 0.25s; background: oklch(0.92 0.015 262); }
 @media (hover: hover) {
   .mist .sph:hover { filter: brightness(0.94); }
 }
@@ -951,6 +1007,12 @@
   .mist .env {
     animation-duration: 0.01s !important;
     animation-delay: 0s !important;
+  }
+  /* 画像プレースホルダーのシマーは静的トーンに */
+  .mist .masonry .tile,
+  .mist .photos .ph {
+    animation: none !important;
+    background: oklch(0.92 0.015 262);
   }
 }
 
@@ -1065,7 +1127,11 @@
   break-inside: avoid;
   overflow: hidden;
   border: 1px solid var(--m-hairline);
-  background: none;
+  /* 読み込み中プレースホルダー（.pcard .thumb と同系のトーン）。
+     画像ロード完了(:has)でアニメーションを止め、合成コストを残さない */
+  background: linear-gradient(105deg, oklch(0.93 0.01 262), oklch(0.89 0.02 262), oklch(0.93 0.01 262));
+  background-size: 300% 100%;
+  animation: m-shimmer 1.8s ease-in-out infinite;
   cursor: zoom-in;
   transition: filter 0.25s;
 }
@@ -1073,6 +1139,10 @@
   .mist .masonry .tile:hover { filter: brightness(0.94); }
 }
 .mist .masonry .tile img { display: block; }
+.mist .masonry .tile:has(img.is-loaded) {
+  animation: none;
+  background: oklch(0.92 0.015 262);
+}
 
 /* 中央寄せの単票（profile / letter） */
 .mist .single { width: 100%; max-width: 520px; margin: 0 auto; }

--- a/src/app/(frontend)/mist.css
+++ b/src/app/(frontend)/mist.css
@@ -72,6 +72,10 @@
   --m-hairline: oklch(0.84 0.02 262); /* hairline（旧 0.80〜0.85 帯を統合） */
   --m-surface: rgba(255, 255, 255, 0.65); /* 半透明パネル面（旧 .5〜.68 を統合） */
   --m-bg: #eef1f4;
+  /* 画像プレースホルダー（装飾）: 基調トーンとシマーの明部/暗部 */
+  --m-ph: oklch(0.92 0.015 262);
+  --m-ph-hi: oklch(0.93 0.01 262);
+  --m-ph-lo: oklch(0.89 0.02 262);
   --m-pad: clamp(20px, 4.5vw, 48px); /* コンテンツ左右パディング（基準 48px） */
 
   /* タイポスケール（役割6段。display系は各要素の clamp を維持） */
@@ -648,13 +652,13 @@
   cursor: zoom-in;
   transition: filter 0.25s;
   /* 読み込み中プレースホルダー（masonry と同じシマー） */
-  background: linear-gradient(105deg, oklch(0.93 0.01 262), oklch(0.89 0.02 262), oklch(0.93 0.01 262));
+  background: linear-gradient(105deg, var(--m-ph-hi), var(--m-ph-lo), var(--m-ph-hi));
   background-size: 300% 100%;
   animation: m-shimmer 1.8s ease-in-out infinite;
 }
 .mist .photos .ph:has(img.is-loaded) {
   animation: none;
-  background: oklch(0.92 0.015 262);
+  background: var(--m-ph);
 }
 @media (hover: hover) {
   .mist .photos .ph:hover { filter: brightness(0.94); }
@@ -909,7 +913,7 @@
 /* minmax(140px): 中央が最小320pxのとき 2 列が成立し、先頭 .big(span 2) が溢れない */
 .mist .gal { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); grid-auto-rows: 1fr; gap: 8px; }
 /* 静的トーンのプレースホルダー（サーバー描画面・マーキーは常時アニメーションを避ける） */
-.mist .gal .g { position: relative; display: block; aspect-ratio: 1; overflow: hidden; border: 0; transition: filter 0.25s; background: oklch(0.92 0.015 262); }
+.mist .gal .g { position: relative; display: block; aspect-ratio: 1; overflow: hidden; border: 0; transition: filter 0.25s; background: var(--m-ph); }
 .mist .gal .g.big { grid-column: span 2; grid-row: span 2; }
 @media (hover: hover) {
   .mist .gal .g:hover { filter: brightness(0.94); }
@@ -942,7 +946,7 @@
 .mist .substream { display: flex; align-items: baseline; gap: 8px; margin: 16px 0 8px; font-size: var(--fs-meta); color: var(--m-sub); }
 .mist .streamwrap { position: relative; overflow: hidden; }
 .mist .streamrow { display: flex; gap: 8px; width: max-content; animation: m-marquee 34s linear infinite; }
-.mist .sph { position: relative; display: block; width: 180px; height: 120px; flex: none; overflow: hidden; border: 0; transition: filter 0.25s; background: oklch(0.92 0.015 262); }
+.mist .sph { position: relative; display: block; width: 180px; height: 120px; flex: none; overflow: hidden; border: 0; transition: filter 0.25s; background: var(--m-ph); }
 @media (hover: hover) {
   .mist .sph:hover { filter: brightness(0.94); }
 }
@@ -1012,7 +1016,7 @@
   .mist .masonry .tile,
   .mist .photos .ph {
     animation: none !important;
-    background: oklch(0.92 0.015 262);
+    background: var(--m-ph);
   }
 }
 
@@ -1129,7 +1133,7 @@
   border: 1px solid var(--m-hairline);
   /* 読み込み中プレースホルダー（.pcard .thumb と同系のトーン）。
      画像ロード完了(:has)でアニメーションを止め、合成コストを残さない */
-  background: linear-gradient(105deg, oklch(0.93 0.01 262), oklch(0.89 0.02 262), oklch(0.93 0.01 262));
+  background: linear-gradient(105deg, var(--m-ph-hi), var(--m-ph-lo), var(--m-ph-hi));
   background-size: 300% 100%;
   animation: m-shimmer 1.8s ease-in-out infinite;
   cursor: zoom-in;
@@ -1141,7 +1145,7 @@
 .mist .masonry .tile img { display: block; }
 .mist .masonry .tile:has(img.is-loaded) {
   animation: none;
-  background: oklch(0.92 0.015 262);
+  background: var(--m-ph);
 }
 
 /* 中央寄せの単票（profile / letter） */

--- a/src/components/gallery/GalleryGridMain.tsx
+++ b/src/components/gallery/GalleryGridMain.tsx
@@ -4,13 +4,13 @@
 'use client'
 
 import { useState } from 'react'
-import Image from 'next/image'
 import { toCFUrl } from '@/lib/cfUrl'
 import ImageModal from '@/components/gallery/ImageModal'
+import SmartImage from '@/components/shared/SmartImage'
 import type { MediaDoc } from '@/lib/payloadTypes'
 
 export default function GalleryGrid({ gallery }: { gallery: MediaDoc[] }) {
-  const [selected, setSelected] = useState<MediaDoc | null>(null)
+  const [selected, setSelected] = useState<{ doc: MediaDoc; poster: string | null } | null>(null)
 
   return (
     <>
@@ -24,13 +24,20 @@ export default function GalleryGrid({ gallery }: { gallery: MediaDoc[] }) {
               type="button"
               className="tile"
               aria-label="画像を拡大表示"
-              onClick={() => setSelected(m)}
+              onClick={(e) =>
+                setSelected({
+                  doc: m,
+                  // ブラウザが実際に描画したURL（=キャッシュ命中確実）をモーダルのポスターに使う
+                  poster: e.currentTarget.querySelector('img')?.currentSrc || null,
+                })
+              }
             >
-              <Image
+              <SmartImage
                 src={src}
                 alt={m.alt ?? ''}
-                width={500}
-                height={500}
+                // 実寸の縦横比を渡し、ロード前からタイルの高さを確定させる（masonry の再流動を防ぐ）
+                width={m.width ?? 500}
+                height={m.height ?? 500}
                 sizes="(min-width:1080px) 25vw, (min-width:720px) 33vw, 50vw"
                 priority={idx === 0}
                 className="object-cover w-full h-auto"
@@ -42,8 +49,14 @@ export default function GalleryGrid({ gallery }: { gallery: MediaDoc[] }) {
 
       {/* 画像モーダル */}
       <ImageModal
-        src={selected?.url ?? selected?.image?.url ?? selected?.sizes?.thumbnail?.url ?? '/fallback.jpg'}
-        alt={selected?.alt ?? ''}
+        src={
+          selected?.doc.url ??
+          selected?.doc.image?.url ??
+          selected?.doc.sizes?.thumbnail?.url ??
+          '/fallback.jpg'
+        }
+        alt={selected?.doc.alt ?? ''}
+        posterSrc={selected?.poster}
         isOpen={!!selected}
         onClose={() => setSelected(null)}
       />

--- a/src/components/gallery/ImageModal.tsx
+++ b/src/components/gallery/ImageModal.tsx
@@ -10,11 +10,14 @@ import { toCFUrl, isOptimizableSrc } from '@/lib/cfUrl'
 interface ImageModalProps {
   src: string
   alt?: string
+  /** 呼び出し元グリッドが描画済みの画像URL（img.currentSrc）。
+      キャッシュ命中で即時表示できるため、原本ロード中のポスターとして使う */
+  posterSrc?: string | null
   isOpen: boolean
   onClose: () => void
 }
 
-export default function ImageModal({ src, alt = '', isOpen, onClose }: ImageModalProps) {
+export default function ImageModal({ src, alt = '', posterSrc, isOpen, onClose }: ImageModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
 
   useEffect(() => {
@@ -49,41 +52,74 @@ export default function ImageModal({ src, alt = '', isOpen, onClose }: ImageModa
       {/* 読み込み状態は ModalBody 内に閉じる。開くたびにマウントし直される
           （閉時にアンマウント + key=src）ため、初回レンダーから必ず loading で
           始まり、前回の loaded/error が次の画像へ漏れない */}
-      {isOpen && src && <ModalBody key={src} src={src} alt={alt} onClose={onClose} />}
+      {isOpen && src && (
+        <ModalBody key={src} src={src} alt={alt} posterSrc={posterSrc} onClose={onClose} />
+      )}
     </dialog>
   )
 }
 
-function ModalBody({ src, alt, onClose }: { src: string; alt: string; onClose: () => void }) {
+function ModalBody({
+  src,
+  alt,
+  posterSrc,
+  onClose,
+}: {
+  src: string
+  alt: string
+  posterSrc?: string | null
+  onClose: () => void
+}) {
   const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading')
+  // 原本と同一URLのポスターは意味がない（同じキャッシュから原本側に即描画される）
+  const poster = posterSrc && posterSrc !== toCFUrl(src) ? posterSrc : null
+
+  const statusPill =
+    status === 'loading' ? (
+      <span className="imgmodal-loading" role="status">
+        <span className="spin" aria-hidden="true" />
+        読み込み中…
+      </span>
+    ) : status === 'error' ? (
+      <span className="imgmodal-error" role="alert">
+        画像を読み込めませんでした
+      </span>
+    ) : null
+
+  const original = (
+    <Image
+      src={toCFUrl(src)}
+      alt={alt}
+      width={1200}
+      height={900}
+      sizes="92vw"
+      className={`imgmodal-img${poster ? ' imgmodal-full' : ''}${status === 'loaded' ? ' is-loaded' : ''}`}
+      onLoad={() => setStatus('loaded')}
+      onError={() => {
+        console.error('ImageModal: 画像の読み込みに失敗しました', src)
+        setStatus('error')
+      }}
+      // リッチテキスト経由で外部ホストの画像も開くため、CF/相対以外は最適化を通さない
+      unoptimized={!isOptimizableSrc(toCFUrl(src))}
+    />
+  )
 
   return (
-    <div className={`imgmodal-body${status !== 'loaded' ? ' is-loading' : ''}`}>
-      <Image
-        src={toCFUrl(src)}
-        alt={alt}
-        width={1200}
-        height={900}
-        sizes="92vw"
-        className={`imgmodal-img${status === 'loaded' ? ' is-loaded' : ''}`}
-        onLoad={() => setStatus('loaded')}
-        onError={() => {
-          console.error('ImageModal: 画像の読み込みに失敗しました', src)
-          setStatus('error')
-        }}
-        // リッチテキスト経由で外部ホストの画像も開くため、CF/相対以外は最適化を通さない
-        unoptimized={!isOptimizableSrc(toCFUrl(src))}
-      />
-      {status === 'loading' && (
-        <span className="imgmodal-loading" role="status">
-          <span className="spin" aria-hidden="true" />
-          読み込み中…
+    <div className={`imgmodal-body${!poster && status !== 'loaded' ? ' is-loading' : ''}`}>
+      {poster ? (
+        // ポスター（描画済みキャッシュ画像）が段のサイズを決め、原本を上に重ねる。
+        // ピルは段の中央にオーバーレイし、原本ロード完了で原本がフェードイン
+        <span className="imgmodal-stage">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={poster} alt="" aria-hidden="true" className="imgmodal-img imgmodal-poster" />
+          {original}
+          {statusPill}
         </span>
-      )}
-      {status === 'error' && (
-        <span className="imgmodal-error" role="alert">
-          画像を読み込めませんでした
-        </span>
+      ) : (
+        <>
+          {original}
+          {statusPill}
+        </>
       )}
       <button
         type="button"

--- a/src/components/gallery/ImageModal.tsx
+++ b/src/components/gallery/ImageModal.tsx
@@ -71,8 +71,10 @@ function ModalBody({
   onClose: () => void
 }) {
   const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading')
-  // 原本と同一URLのポスターは意味がない（同じキャッシュから原本側に即描画される）
-  const poster = posterSrc && posterSrc !== toCFUrl(src) ? posterSrc : null
+  const [posterFailed, setPosterFailed] = useState(false)
+  // 原本と同一URLのポスターは意味がない（同じキャッシュから原本側に即描画される）。
+  // ポスター自体の取得失敗時は通常表示（is-loading の確保領域+ピル）へ戻す
+  const poster = !posterFailed && posterSrc && posterSrc !== toCFUrl(src) ? posterSrc : null
 
   const statusPill =
     status === 'loading' ? (
@@ -110,8 +112,18 @@ function ModalBody({
         // ポスター（描画済みキャッシュ画像）が段のサイズを決め、原本を上に重ねる。
         // ピルは段の中央にオーバーレイし、原本ロード完了で原本がフェードイン
         <span className="imgmodal-stage">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={poster} alt="" aria-hidden="true" className="imgmodal-img imgmodal-poster" />
+          <Image
+            src={poster}
+            alt=""
+            aria-hidden="true"
+            width={1200}
+            height={900}
+            sizes="92vw"
+            className="imgmodal-img imgmodal-poster"
+            // currentSrc(最適化済みURL)を再最適化せず素通しし、キャッシュ命中を保つ
+            unoptimized
+            onError={() => setPosterFailed(true)}
+          />
           {original}
           {statusPill}
         </span>

--- a/src/components/mist/MistLogTimeline.tsx
+++ b/src/components/mist/MistLogTimeline.tsx
@@ -6,9 +6,9 @@
 'use client'
 
 import { type CSSProperties, useEffect, useRef, useState } from 'react'
-import Image from 'next/image'
 import Link from 'next/link'
 import ImageModal from '@/components/gallery/ImageModal'
+import SmartImage from '@/components/shared/SmartImage'
 import RichTextRenderer from '@/components/shared/RichTextRenderer'
 import UrlPreview from '@/components/shared/UrlPreview'
 import { toCFUrl } from '@/lib/cfUrl'
@@ -126,7 +126,7 @@ function PhotoGrid({
 }: {
   photos: TLImage[]
   title?: string | null
-  onOpen: (url: string) => void
+  onOpen: (url: string, poster: string | null) => void
 }) {
   const items = photos.slice(0, 4)
   const n = items.length
@@ -156,9 +156,12 @@ function PhotoGrid({
             className="ph"
             style={style}
             aria-label="画像を拡大表示"
-            onClick={() => onOpen(im.url)}
+            onClick={(e) =>
+              // 描画済みURL（=キャッシュ命中確実）をモーダルのポスターに渡す
+              onOpen(im.url, e.currentTarget.querySelector('img')?.currentSrc || null)
+            }
           >
-            <Image
+            <SmartImage
               src={toCFUrl(url)}
               alt={title ?? 'timeline photo'}
               fill
@@ -217,7 +220,7 @@ type Props = {
 
 export default function MistLogTimeline({ posts, total, showHead = true, compact = false }: Props) {
   const [filter, setFilter] = useState('all')
-  const [modalImg, setModalImg] = useState<string | null>(null)
+  const [modalImg, setModalImg] = useState<{ src: string; poster: string | null } | null>(null)
   const [feeds, setFeeds] = useState<Record<string, FeedState>>({
     all: {
       docs: posts,
@@ -274,8 +277,9 @@ export default function MistLogTimeline({ posts, total, showHead = true, compact
   return (
     <div>
       <ImageModal
-        src={modalImg ?? ''}
+        src={modalImg?.src ?? ''}
         alt="timeline-modal-img"
+        posterSrc={modalImg?.poster}
         isOpen={!!modalImg}
         onClose={() => setModalImg(null)}
       />
@@ -338,7 +342,11 @@ export default function MistLogTimeline({ posts, total, showHead = true, compact
               )}
 
               {photos.length > 0 && (
-                <PhotoGrid photos={photos} title={post.title} onOpen={setModalImg} />
+                <PhotoGrid
+                  photos={photos}
+                  title={post.title}
+                  onOpen={(src, poster) => setModalImg({ src, poster })}
+                />
               )}
 
               <MistLike id={post.id} initialLikes={post.likes ?? 0} />

--- a/src/components/shared/SmartImage.tsx
+++ b/src/components/shared/SmartImage.tsx
@@ -5,20 +5,29 @@
 import Image, { type ImageProps } from 'next/image'
 import { useCallback, useState } from 'react'
 
-export default function SmartImage({ className, ...props }: Omit<ImageProps, 'onLoad'>) {
-  const [loaded, setLoaded] = useState(false)
+export default function SmartImage({ className, ...props }: Omit<ImageProps, 'onLoad' | 'onError'>) {
+  // 成功/失敗を問わず「確定」でフェード表示に切り替える。失敗を loading のまま
+  // 残すと、壊れた画像が透明のままシマーが無限に続いてしまう
+  const [settled, setSettled] = useState(false)
   // SSR済み・キャッシュ済みでハイドレーション前に complete になった画像は
-  // onLoad が発火しないため、ref 側で検出して透明のまま残らないようにする
+  // onLoad/onError が発火しないため、ref 側で検出して透明のまま残らないようにする
   const ref = useCallback((img: HTMLImageElement | null) => {
-    if (img && img.complete && img.naturalWidth > 0) setLoaded(true)
+    if (img && img.complete) setSettled(true)
   }, [])
 
   return (
     <Image
       {...props}
       ref={ref}
-      onLoad={() => setLoaded(true)}
-      className={`${className ?? ''} imgfade${loaded ? ' is-loaded' : ''}`.trim()}
+      onLoad={() => setSettled(true)}
+      onError={() => {
+        console.error(
+          'SmartImage: 画像の読み込みに失敗しました',
+          typeof props.src === 'string' ? props.src : '',
+        )
+        setSettled(true)
+      }}
+      className={`${className ?? ''} imgfade${settled ? ' is-loaded' : ''}`.trim()}
     />
   )
 }

--- a/src/components/shared/SmartImage.tsx
+++ b/src/components/shared/SmartImage.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+// 読み込み完了までコンテナ側のプレースホルダー（シマー/トーン）を見せ、
+// 完了時にフェードインする next/image ラッパー。
+import Image, { type ImageProps } from 'next/image'
+import { useCallback, useState } from 'react'
+
+export default function SmartImage({ className, ...props }: Omit<ImageProps, 'onLoad'>) {
+  const [loaded, setLoaded] = useState(false)
+  // SSR済み・キャッシュ済みでハイドレーション前に complete になった画像は
+  // onLoad が発火しないため、ref 側で検出して透明のまま残らないようにする
+  const ref = useCallback((img: HTMLImageElement | null) => {
+    if (img && img.complete && img.naturalWidth > 0) setLoaded(true)
+  }, [])
+
+  return (
+    <Image
+      {...props}
+      ref={ref}
+      onLoad={() => setLoaded(true)}
+      className={`${className ?? ''} imgfade${loaded ? ' is-loaded' : ''}`.trim()}
+    />
+  )
+}

--- a/src/lib/payloadTypes.ts
+++ b/src/lib/payloadTypes.ts
@@ -52,6 +52,9 @@ export interface MediaDoc extends BaseDoc {
   image?: { url?: string; sizes?: Record<string, { url: string }> }
   /** 生成された各サイズのURL */
   sizes?: Record<string, { url: string }>
+  /** 原本の実寸（sharp 設定時に Payload が自動格納） */
+  width?: number
+  height?: number
   /** alt テキスト */
   alt?: string
   /** タイムライン専用フラグ */

--- a/src/lib/renderRichTextWithModal.tsx
+++ b/src/lib/renderRichTextWithModal.tsx
@@ -32,7 +32,7 @@ const defaultClassNames: Record<string, string> = {
 }
 
 export function RenderRichTextWithModal({ nodes = [], keyPrefix = 'rt' }: { nodes: LexicalNode[], keyPrefix?: string }): ReactNode {
-  const [modalImage, setModalImage] = useState<{ src: string; alt: string; width?: number; height?: number } | null>(null)
+  const [modalImage, setModalImage] = useState<{ src: string; alt: string; poster?: string | null; width?: number; height?: number } | null>(null)
 
   const renderNodes = (nodeList: LexicalNode[] = [], prefix = 'rt'): ReactNode[] => {
     return nodeList.map((node, idx) => {
@@ -113,9 +113,11 @@ export function RenderRichTextWithModal({ nodes = [], keyPrefix = 'rt' }: { node
               sizes="(max-width: 768px) 100vw, 160px"
               className="rounded-lg cursor-pointer hover:opacity-80 transition-opacity object-cover max-w-[160px] h-auto"
               unoptimized={!isOptimizableSrc(imageSrc)}
-              onClick={() => setModalImage({
+              onClick={(e) => setModalImage({
                 src: imageSrc,
                 alt: node.alt || '',
+                // インライン表示済みのURL（=キャッシュ命中確実）をモーダルのポスターに使う
+                poster: e.currentTarget.currentSrc || null,
                 width: 800,
                 height: 600
               })}
@@ -165,6 +167,7 @@ export function RenderRichTextWithModal({ nodes = [], keyPrefix = 'rt' }: { node
       <ImageModal
         src={modalImage?.src || ''}
         alt={modalImage?.alt || ''}
+        posterSrc={modalImage?.poster}
         isOpen={!!modalImage}
         onClose={() => setModalImage(null)}
       />


### PR DESCRIPTION
## 目的

ギャラリー等の画像読み込み待ちがスマートでなく、ユーザーのストレスになっていた。原因は2点:

1. **モーダル**: グリッドに表示済み（=ブラウザキャッシュに確実にある）の画像を活かさず、原本ロード完了までスピナーだけを見せていた
2. **グリッド類**: プレースホルダーが無く、真っ白なまま画像が突然ポップインしていた

## 実装

### B. モーダルのぼかしポスター（本命）
クリック時に `img.currentSrc`（ブラウザが実際に描画した最適化変換URL＝キャッシュ命中が確実）を `posterSrc` としてモーダルへ渡し、**ぼかした状態で原本の表示サイズまで拡大して即時表示**。原本はロード完了後その上にフェードインする（Instagram/Unsplash方式のblur-up）。ピルはポスター中央にオーバーレイ。低解像度ポスターの拡大は `width: 92vw` + 既存 `max-height` の置換要素制約解決（縦横比保持）で原本と同じcontain寸法になる。
※ `imageSizes` 未設定のため `sizes?.thumbnail` は常に undefined でグリッド・モーダルとも原本URL参照（optimizerの変換幅だけが違う）という現状も踏まえた設計。

### A. プレースホルダー
- 待ちが視認される面（ギャラリーmasonry・タイムライン写真）: 低コントラストのシマー。**`:has(img.is-loaded)` でロード完了後はアニメーションを停止**し合成コストを残さない（PR #56 のモバイル性能方針を踏襲）
- サーバー描画面（Home gal・マーキー）: 常時アニメーションを避け静的トーンのみ。カード類は既存の背景を維持
- reduced-motion: シマーは静的トーンへ

### C. フェードイン（SmartImage）
クライアント面（masonry・タイムライン写真）の画像を共通ラッパー `SmartImage` に置換。完了時に0.3sフェードイン。**SSR済み・ハイドレーション前に `complete` になった画像は ref コールバックで検出**し、`onLoad` 不発で透明のまま残る事故を防ぐ。

### 付随
- masonry タイルへ Media 実寸 `width/height` を渡し、ロード前から縦横比を確定（列の再流動を防止）。`MediaDoc` 型に `width/height` を追加（Payload が sharp 設定時に自動格納する実在フィールド）

## 検証

- mist.css転記+preflight相当の再現ページをPlaywrightで確認:
  - グリッド途中状態: ロード済みタイルは表示・未ロードはシマー（縦横比確保済み）
  - モーダル: ポスター即時表示 370×278 ≒ 原本ロード後 359×270（同位置・同寸、blur+scale1.03分の差のみ）
- `pnpm typecheck` / `pnpm lint` / `pnpm test` / `next build --experimental-build-mode compile` すべて通過

## 見送り（deferred）

- Payload `imageSizes` による実サムネイル生成（スキーマ変更+マイグレーション+既存画像の再生成が必要。optimizerが変換を担っている現状では効果が限定的）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 写真やギャラリー画像に、読み込み中のシマー表示を追加しました。
  - 画像読み込み完了時のフェードイン表示に対応しました。
  - 画像モーダルでポスター画像を表示し、原本の読み込み中も内容を確認できるようになりました。
  - 読み込みエラー時の案内表示を追加しました。
  - 端末の「視差効果を減らす」設定時は、シマーアニメーションを無効化します。

- **改善**
  - ギャラリー画像を実際の縦横比で表示するよう改善しました。
  - キャッシュ済み画像も適切に表示状態へ切り替わるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->